### PR TITLE
fix jolt cli example in docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,7 @@ The bin/ directory contains a command line interface (CLI) tool for using some o
 The Jolt tool has the ability to accept input from standard in:
 
     curl -s "http://some.json.api.com/data/you/will/take/our/stupid/format/and/like/it" | jolt transform makeSaneSpec.json | jolt sort
-    curl -s "http://some.host.com/stuff/data.json" | jolt diffy moreData.json | jolt sort
+    curl -s "http://some.host.com/stuff/data.json" | jolt diffy moreData.json
 
 # Setup
 


### PR DESCRIPTION
The example I had before would cause an error, since the output of diffy is not properly formatted JSON
