### PR TITLE
Prevent Sortr from throwing UnsupportedOperationException 

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Sortr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Sortr.java
@@ -23,17 +23,19 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Recursively sorts all maps within a JSON object into sorted LinkedHashMaps so that serialized
+ * Recursively sorts all maps within a JSON object into new sorted LinkedHashMaps so that serialized
  * representations are deterministic.  Useful for debugging and making test fixtures.
+ *
+ * Note this will make a copy of the input Map and List objects.
  *
  * The sort order is standard alphabetical ascending, with a special case for "~" prefixed keys to be bumped to the top.
  */
 public class Sortr implements Transform {
 
     /**
-     * Sorts the JSON for human readability.
+     * Makes a "sorted" copy of the input Json for human readability.
      *
-     * @param input the JSON object to transform in plain vanilla Jackson Map<String, Object> style
+     * @param input the JSON object to transform, in plain vanilla Jackson Map<String, Object> style
      */
     @Override
     public Object transform( Object input ) {
@@ -62,12 +64,13 @@ public class Sortr implements Transform {
     }
 
     private static List<Object> ordered( List<Object> list ) {
-        // don't sort the list because that would change intent, but sort its components
-        for ( int index = 0; index < list.size(); index++ ) {
-            Object obj = list.get( index );
-            list.set( index, sortJson( obj ) );
+        // Don't sort the list because that would change intent, but sort its components
+        // Additionally, make a copy of the List in-case the provided list is Immutable / Unmodifiable
+        List<Object> newList = new ArrayList<Object>( list.size() );
+        for ( Object obj : list ) {
+            newList.add( sortJson( obj ) );
         }
-        return list;
+        return newList;
     }
 
     private static JsonKeyComparator jsonKeyComparator = new JsonKeyComparator();

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/SortrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/SortrTest.java
@@ -15,12 +15,16 @@
  */
 package com.bazaarvoice.jolt;
 
+import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
 import org.testng.AssertJUnit;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +34,7 @@ public class SortrTest {
     @DataProvider
     public Object[][] getTestCaseNames() {
         return new Object[][] {
-            {"simple" }
+            { "simple" }
         };
     }
 
@@ -97,5 +101,24 @@ public class SortrTest {
         }
 
         return null; // success
+    }
+
+    @Test
+    public void testDoesNotBlowUpOnUnmodifiableArray() {
+        List<Object> hasNan = new ArrayList<Object>();
+        hasNan.add( 1 );
+        hasNan.add( Double.NaN );
+        hasNan.add( 2 );
+
+        Map map = new HashMap();
+        map.put("a", "shouldBeFirst");
+        map.put("hasNan", Collections.unmodifiableList( hasNan ) );
+
+        try {
+            Sortr.sortJson( map );
+        }
+        catch( UnsupportedOperationException uoe ) {
+            Assert.fail( "Sort threw a UnsupportedOperationException" );
+        }
     }
 }


### PR DESCRIPTION
When "sorting" an Immutable / Unmodifiable List.

Note, we are not "sorting" the list, as that would change the semantics of the list, but instead making a sorted copy of each element.
