### PR TITLE
bump Guava to 16.0.1 - this release fixes the nasty incompatibility with JDK 1.7.0_51

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,7 +34,7 @@
         <argparse4j.version>0.4.2</argparse4j.version>
 
         <!-- TEST -->
-        <guava.version>15.0</guava.version>
+        <guava.version>16.0.1</guava.version>
         <testng.version>6.8.7</testng.version>
     </properties>
 


### PR DESCRIPTION
Reference:

http://jaxenter.com/java-security-patch-breaks-guava-library-49360.html
https://code.google.com/p/guava-libraries/issues/detail?id=1635
