### PR TITLE
Added new feature for Remover to be able to remove JsonArray

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
@@ -17,10 +17,7 @@ package com.bazaarvoice.jolt.removr.spec;
 import com.bazaarvoice.jolt.common.pathelement.LiteralPathElement;
 import com.bazaarvoice.jolt.exception.SpecException;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /*
     Sample Spec
@@ -86,6 +83,19 @@ public class RemovrCompositeSpec extends RemovrSpec {
         }
     }
 
+    @Override
+    public void removeJsonArrayFields(List<LinkedHashMap<String, Object>> input) {
+        if (pathElement instanceof  LiteralPathElement) {
+            for (LinkedHashMap<String, Object> list : input) {
+                handleLiterals(list);
+            }
+        } else {
+            for (LinkedHashMap<String, Object> list : input) {
+                handleComputed(createMapForList(list));
+            }
+        }
+    }
+
     /** +
      *
      * @param inputMap : Input map from which the spec keys need to be removed
@@ -98,6 +108,10 @@ public class RemovrCompositeSpec extends RemovrSpec {
             for(RemovrSpec childSpec : allChildren){
                 // Recursive call if composite spec, else removes the element from the map if it is a leaf spec.
                 childSpec.remove((Map<String, Object>) subInput);
+            }
+        } else if (subInput instanceof List) {
+            for(RemovrSpec childSpec : allChildren) {
+                childSpec.removeJsonArrayFields((List<LinkedHashMap<String, Object>>) subInput);
             }
         }
     }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.removr.spec;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +44,19 @@ public class RemovrLeafSpec extends RemovrSpec {
        List<String> keysToBeRemoved = findKeysToBeRemoved(input);
         for (String key : keysToBeRemoved){
             removeByKey(input, key);
+        }
+    }
+
+    @Override
+    public void removeJsonArrayFields(List<LinkedHashMap<String, Object>> input) {
+        if(input == null) {
+            return;
+        }
+        for (LinkedHashMap<String, Object> list : input) {
+            List<String> keysToBeRemoved = findKeysToBeRemoved(list);
+            for (String key : keysToBeRemoved) {
+                removeByKey(list, key);
+            }
         }
     }
 

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
@@ -26,10 +26,7 @@ import com.bazaarvoice.jolt.common.pathelement.StarPathElement;
 import com.bazaarvoice.jolt.exception.SpecException;
 import com.bazaarvoice.jolt.utils.StringTools;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public abstract class RemovrSpec {
 
@@ -89,7 +86,15 @@ public abstract class RemovrSpec {
         return keysToBeRemoved;
     }
 
+    public Map<String, Object> createMapForList(LinkedHashMap<String, Object> listInput) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("root", listInput);
+        return map;
+    }
+
     public abstract void remove(Map<String, Object> input);
+
+    public abstract void removeJsonArrayFields(List<LinkedHashMap<String, Object>> input);
 
     public abstract void removeByKey(Map<String, Object> inputMap, String key);
 }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
@@ -31,7 +31,8 @@ public class RemovrTest {
         {"boundaryConditions"},
         {"removrWithWildcardSupport"},
         {"multiStarSupport"},
-        {"starDoublePathElementBoundaryConditions"}
+        {"starDoublePathElementBoundaryConditions"},
+        {"removeJsonArrayFields"}
 
         };
     }

--- a/jolt-core/src/test/resources/json/removr/removeJsonArrayFields.json
+++ b/jolt-core/src/test/resources/json/removr/removeJsonArrayFields.json
@@ -1,0 +1,38 @@
+{
+  "input": {
+
+    "arrayObjects": [
+      {
+        "removeThis": "gone",
+        "testStay": "here"
+      },
+      {
+        "removeThis": "remove",
+        "testStay": "still here"
+      }
+    ],
+    "arrayString" : ["entire", "field", "gone"]
+  },
+
+  "spec": {
+
+    "arrayObjects": {
+      "*": {
+        "removeThis": ""
+      }
+    },
+    "arrayString": ""
+
+  },
+
+  "expected": {
+    "arrayObjects": [
+      {
+        "testStay": "here"
+      },
+      {
+        "testStay": "still here"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This is a new feature for Removr to be able to remove Json Array fields.

Input:
```json
{
    "arrayObjects": [
        {
            "removeThis": "gone",
            "testStay": "here"
        },
        {
            "removeThis": "remove",
            "testStay": "still here"
        }
    ],
    "arrayString": [
        "entire",
        "field",
        "gone"
    ]
}
```
Spec:
```json
{
    "arrayObjects": {
        "*": {
            "removeThis": ""
        }
    },
    "arrayString": ""
}
```
Expected:
```json
{
    "arrayObjects": [
        {
            "testStay": "here"
        },
        {
            "testStay": "still here"
        }
    ]
}
```