### PR TITLE
Update RemovrCompositeSpec exception message

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
@@ -62,7 +62,7 @@ public class RemovrCompositeSpec extends RemovrSpec {
                     childSpec = new RemovrLeafSpec(keyString);
                 }
                 else{
-                    throw new SpecException("Invalid Removr spec RHS. Should be a non-empty string or Map");
+                    throw new SpecException("Invalid Removr spec RHS. Should be an empty string or Map");
                 }
                 all.add(childSpec);
             }


### PR DESCRIPTION
Fix the SpecException message.  Spec is expecting empty string for leaf nodes.

Have not run any tests to verify the change, but the message is clearly incorrect.