### PR TITLE
Removr now can handle nested Arrays

### DIFF
--- a/cli/src/main/java/com/bazaarvoice/jolt/TransformCliProcessor.java
+++ b/cli/src/main/java/com/bazaarvoice/jolt/TransformCliProcessor.java
@@ -15,7 +15,6 @@
  */
 package com.bazaarvoice.jolt;
 
-import com.bazarvoice.jolt.ChainrFactory;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;

--- a/complete/src/main/java/com/bazaarvoice/jolt/ChainrFactory.java
+++ b/complete/src/main/java/com/bazaarvoice/jolt/ChainrFactory.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.bazarvoice.jolt;
+package com.bazaarvoice.jolt;
 
-import com.bazaarvoice.jolt.Chainr;
-import com.bazaarvoice.jolt.JsonUtils;
 import com.bazaarvoice.jolt.chainr.instantiator.ChainrInstantiator;
 
 import java.io.File;

--- a/complete/src/test/java/com/bazaarvoice/jolt/ChainrFactoryTest.java
+++ b/complete/src/test/java/com/bazaarvoice/jolt/ChainrFactoryTest.java
@@ -16,7 +16,6 @@
 package com.bazaarvoice.jolt;
 
 import com.bazaarvoice.jolt.chainr.instantiator.DefaultChainrInstantiator;
-import com.bazarvoice.jolt.ChainrFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
@@ -91,7 +91,7 @@ import java.util.Map;
  *      },
  *    }
  *    //desired output
- *     {
+ *    {
  *     "ratings":{
  *        "Set1":{
  *           "a":"a"
@@ -153,12 +153,30 @@ import java.util.Map;
  *              "Set1":""
  *       }
  *    </pre>
- *
- *
  * <p/>
- * The Spec file format for Removr is a tree Map<String, Object> objects.
- * The "Right hand side" of the of each entry is ignored/irrelevant unless it is a map,
- *  in which case Removr will recursively walk down the tree.
+ *
+ * <p>
+ *  * Arrays
+ *
+ * Removr can also handle data in Arrays.
+ *
+ *  It can walk thru all the elements of an array with the "*" wildcard.
+ *
+ *  Additionally, it can remove individual array indicies.  To do this the LHS key
+ *   must be a number but in String format.
+ *
+ *  Example
+ *  <pre>
+ *  "spec": {
+ *    "array": {
+ *      "0" : ""
+ *    }
+ *  }
+ *  </pre>
+ *
+ *  In this case, Removr will remove the zero-th item from the input "array", which will cause data at
+ *   index "1" to become the new "0".  Because of this, Remover matches all the literal/explicit
+ *   indices first, sorts them from Biggest to Smallest, then does the removing.
  * <p/>
  */
 public class Removr implements SpecDriven, Transform {
@@ -193,7 +211,7 @@ public class Removr implements SpecDriven, Transform {
         // Wrap the input in a map to fool the CompositeSpec to recurse itself.
         Map<String,Object> wrappedMap = new HashMap<>();
         wrappedMap.put(ROOT_KEY, input);
-        rootSpec.remove(wrappedMap);
+        rootSpec.applySpec(wrappedMap);
         return input;
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
@@ -207,7 +207,7 @@ public class Removr implements SpecDriven, Transform {
         // Wrap the input in a map to fool the CompositeSpec to recurse itself.
         Map<String,Object> wrappedMap = new HashMap<>();
         wrappedMap.put(ROOT_KEY, input);
-        rootSpec.applySpec(wrappedMap);
+        rootSpec.applyToMap( wrappedMap );
         return input;
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java
@@ -203,11 +203,7 @@ public class Removr implements SpecDriven, Transform {
      */
     @Override
     public Object transform( Object input ) {
-        return transformInternal(input);
-    }
 
-    private  Object transformInternal(Object input)
-    {
         // Wrap the input in a map to fool the CompositeSpec to recurse itself.
         Map<String,Object> wrappedMap = new HashMap<>();
         wrappedMap.put(ROOT_KEY, input);

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrCompositeSpec.java
@@ -110,7 +110,7 @@ public class RemovrCompositeSpec extends RemovrSpec {
             // IF the input is a List, the only thing that will match is a Literal or a "*"
             if ( pathElement instanceof LiteralPathElement ) {
 
-                Integer pathElementInt = getIntegerFromLiteralPathElement();
+                Integer pathElementInt = getNonNegativeIntegerFromLiteralPathElement();
 
                 if ( pathElementInt != null && pathElementInt < inputList.size() ) {
                     Object subObj = inputList.get( pathElementInt );
@@ -136,11 +136,16 @@ public class RemovrCompositeSpec extends RemovrSpec {
 
                 Set<Integer> indiciesToRemove = new HashSet<>();
 
+                // build a list of all indicies to remove
                 for(RemovrSpec childSpec : children) {
                     indiciesToRemove.addAll( childSpec.applySpec( subInput ) );
                 }
 
                 List<Integer> uniqueIndiciesToRemove = new ArrayList<>( indiciesToRemove );
+                // Sort the list from Biggest to Smallest, so that when we remove items from the input
+                //  list we don't muck up the order.
+                // Aka removing 0 _then_ 3 would be bad, because we would of actually removed
+                //  0 and 4 from the "original" list.
                 Collections.sort( uniqueIndiciesToRemove, new Comparator<Integer>() {
                     @Override
                     public int compare( Integer o1, Integer o2 ) {

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 /** +
- * Spec for handling the leaf spec in Removr Transforms.
+ * Spec for handling the leaf spec of the Removr Transform.
  */
 public class RemovrLeafSpec extends RemovrSpec {
 
@@ -71,7 +71,7 @@ public class RemovrLeafSpec extends RemovrSpec {
 
             if ( pathElement instanceof LiteralPathElement ) {
 
-                Integer pathElementInt = getIntegerFromLiteralPathElement();
+                Integer pathElementInt = getNonNegativeIntegerFromLiteralPathElement();
 
                 if ( pathElementInt != null && pathElementInt < inputList.size() ) {
                     return Collections.singletonList( pathElementInt );
@@ -80,8 +80,8 @@ public class RemovrLeafSpec extends RemovrSpec {
             else if ( pathElement instanceof StarAllPathElement ) {
 
                 // To be clear, this is kinda silly.
-                // If you just wanted to remove the whole list just remove it.
-                // The effectively clears the list.
+                // If you just wanted to remove the whole list, you could have just
+                //  directly removed it, instead of stepping into it and using the "*".
                 List<Integer> toReturn = new ArrayList<>( inputList.size() );
                 for( int index = 0; index < inputList.size(); index++ ) {
                     toReturn.add( index );
@@ -92,26 +92,5 @@ public class RemovrLeafSpec extends RemovrSpec {
         }
 
         return Collections.emptyList();
-    }
-
-    /**
-     * @param input : Input map from which the literal/computed keys that match the Spec needs to be removed.
-     * For starpathelements, go through all the input keys and check whether this pathelement key is a match.
-     */
-    public List<String> findKeysToRecurseOn( Map<String, Object> input ) {
-
-        ArrayList<String> keysToBeRemoved = new ArrayList<>();
-        boolean isStarPathElement = pathElement instanceof StarPathElement;
-        for (String ipkey : input.keySet()) {
-            if (isStarPathElement) {
-                if ( ( (StarPathElement) pathElement).stringMatch( ipkey ) ) {
-                    keysToBeRemoved.add(ipkey);
-                }
-            } else {
-
-                keysToBeRemoved.add(pathElement.getRawKey());
-            }
-        }
-        return keysToBeRemoved;
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
@@ -25,8 +25,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-/** +
- * Spec for handling the leaf spec of the Removr Transform.
+/**
+ * Spec for handling the leaf level of the Removr Transform.
  */
 public class RemovrLeafSpec extends RemovrSpec {
 
@@ -35,45 +35,47 @@ public class RemovrLeafSpec extends RemovrSpec {
     }
 
     /**
+     * Build a list of keys to remove from the input map, using the pathElement
+     *  from the Spec.
+     *
      * @param inputMap : Input map from which the spec key needs to be removed.
      */
     @Override
-    public List<String> applySpec( Map<String,Object> inputMap ) {
+    public List<String> applyToMap( Map<String, Object> inputMap ) {
         if ( inputMap == null ) {
             return null;
         }
 
+        List<String> keysToBeRemoved = new LinkedList<>();
 
         if ( pathElement instanceof LiteralPathElement ) {
-            inputMap.remove( pathElement.getRawKey() );
+
+            // if we are a literal, check to see if we match
+            if ( inputMap.containsKey( pathElement.getRawKey() ) ) {
+                keysToBeRemoved.add( pathElement.getRawKey() );
+            }
         }
         else if ( pathElement instanceof StarPathElement ) {
 
-            List<String> keysToBeRemoved = new LinkedList<>();
-            for( Map.Entry<String,Object> entry : inputMap.entrySet() ) {
+            StarPathElement star = (StarPathElement) pathElement;
 
-                StarPathElement star = (StarPathElement) pathElement;
+            // if we are a wildcard, check each input key to see if it matches us
+            for( String key : inputMap.keySet() ) {
 
-                if ( star.stringMatch( entry.getKey() ) ) {
-                    keysToBeRemoved.add( entry.getKey() );
+                if ( star.stringMatch( key ) ) {
+                    keysToBeRemoved.add( key );
                 }
-            }
-
-            for ( String key : keysToBeRemoved ) {
-                inputMap.remove( key );
             }
         }
 
-        return Collections.emptyList();
+        return keysToBeRemoved;
     }
 
-
-
     /**
-     * @param inputList : Input map from which the spec key needs to be removed.
+     * @param inputList : Input List from which the spec key needs to be removed.
      */
     @Override
-    public List<Integer> applySpec( List<Object> inputList ) {
+    public List<Integer> applyToList( List<Object> inputList ) {
         if ( inputList == null ) {
             return null;
         }
@@ -98,7 +100,10 @@ public class RemovrLeafSpec extends RemovrSpec {
 
             return toReturn;
         }
+        // else the pathElement is some other kind which is not supported when running
+        //  against arrays, aka "tuna*" makes no sense against a list.
 
-         return Collections.emptyList();
+
+        return Collections.emptyList();
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrLeafSpec.java
@@ -35,62 +35,70 @@ public class RemovrLeafSpec extends RemovrSpec {
     }
 
     /**
-     * @param input : Input map from which the spec key needs to be removed.
+     * @param inputMap : Input map from which the spec key needs to be removed.
      */
     @Override
-    public List<Integer> applySpec( Object input ) {
-        if ( input == null ) {
+    public List<String> applySpec( Map<String,Object> inputMap ) {
+        if ( inputMap == null ) {
             return null;
         }
 
-        if ( input instanceof Map ) {
-            Map<String,Object> inputMap = (Map<String,Object>) input;
 
-            if ( pathElement instanceof LiteralPathElement ) {
-                inputMap.remove( pathElement.getRawKey() );
-            }
-            else if ( pathElement instanceof StarPathElement ) {
-
-                List<String> keysToBeRemoved = new LinkedList<>();
-                for( Map.Entry<String,Object> entry : inputMap.entrySet() ) {
-
-                    StarPathElement star = (StarPathElement) pathElement;
-
-                    if ( star.stringMatch( entry.getKey() ) ) {
-                        keysToBeRemoved.add( entry.getKey() );
-                    }
-                }
-
-                for ( String key : keysToBeRemoved ) {
-                    inputMap.remove( key );
-                }
-            }
+        if ( pathElement instanceof LiteralPathElement ) {
+            inputMap.remove( pathElement.getRawKey() );
         }
-        else if ( input instanceof List ) {
-            List<Object> inputList = (List<Object>) input;
+        else if ( pathElement instanceof StarPathElement ) {
 
-            if ( pathElement instanceof LiteralPathElement ) {
+            List<String> keysToBeRemoved = new LinkedList<>();
+            for( Map.Entry<String,Object> entry : inputMap.entrySet() ) {
 
-                Integer pathElementInt = getNonNegativeIntegerFromLiteralPathElement();
+                StarPathElement star = (StarPathElement) pathElement;
 
-                if ( pathElementInt != null && pathElementInt < inputList.size() ) {
-                    return Collections.singletonList( pathElementInt );
+                if ( star.stringMatch( entry.getKey() ) ) {
+                    keysToBeRemoved.add( entry.getKey() );
                 }
             }
-            else if ( pathElement instanceof StarAllPathElement ) {
 
-                // To be clear, this is kinda silly.
-                // If you just wanted to remove the whole list, you could have just
-                //  directly removed it, instead of stepping into it and using the "*".
-                List<Integer> toReturn = new ArrayList<>( inputList.size() );
-                for( int index = 0; index < inputList.size(); index++ ) {
-                    toReturn.add( index );
-                }
-
-                return toReturn;
+            for ( String key : keysToBeRemoved ) {
+                inputMap.remove( key );
             }
         }
 
         return Collections.emptyList();
+    }
+
+
+
+    /**
+     * @param inputList : Input map from which the spec key needs to be removed.
+     */
+    @Override
+    public List<Integer> applySpec( List<Object> inputList ) {
+        if ( inputList == null ) {
+            return null;
+        }
+
+        if ( pathElement instanceof LiteralPathElement ) {
+
+            Integer pathElementInt = getNonNegativeIntegerFromLiteralPathElement();
+
+            if ( pathElementInt != null && pathElementInt < inputList.size() ) {
+                return Collections.singletonList( pathElementInt );
+            }
+        }
+        else if ( pathElement instanceof StarAllPathElement ) {
+
+            // To be clear, this is kinda silly.
+            // If you just wanted to remove the whole list, you could have just
+            //  directly removed it, instead of stepping into it and using the "*".
+            List<Integer> toReturn = new ArrayList<>( inputList.size() );
+            for( int index = 0; index < inputList.size(); index++ ) {
+                toReturn.add( index );
+            }
+
+            return toReturn;
+        }
+
+         return Collections.emptyList();
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
@@ -59,20 +59,30 @@ public abstract class RemovrSpec {
         }
     }
 
-    protected Integer getIntegerFromLiteralPathElement() {
+    protected Integer getNonNegativeIntegerFromLiteralPathElement() {
 
         Integer pathElementInt = null;
 
         try {
             pathElementInt = Integer.parseInt( pathElement.getRawKey() );
+
+            if ( pathElementInt < 0 ) {
+                return null;
+            }
         }
         catch( NumberFormatException nfe ) {
             // If the data is an Array, but the spec keys are Non-Integer Strings,
             //  we are annoyed, but we don't stop the whole transform.
             // Just this part of the Transform won't work.
         }
+
         return pathElementInt;
     }
 
+    /**
+     *
+     * @param input
+     * @return If the input was a list, this the indicies to remove, otherwise empty List.
+     */
     public abstract List<Integer> applySpec(Object input);
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
@@ -26,6 +26,7 @@ import com.bazaarvoice.jolt.exception.SpecException;
 import com.bazaarvoice.jolt.utils.StringTools;
 
 import java.util.List;
+import java.util.Map;
 
 public abstract class RemovrSpec {
 
@@ -59,6 +60,11 @@ public abstract class RemovrSpec {
         }
     }
 
+    /**
+     * Try to "interpret" the spec String value as a non-negative integer.
+     *
+     * @return non-negative integer, otherwise null
+     */
     protected Integer getNonNegativeIntegerFromLiteralPathElement() {
 
         Integer pathElementInt = null;
@@ -80,9 +86,14 @@ public abstract class RemovrSpec {
     }
 
     /**
-     *
-     * @param input
+     * @param input List
      * @return If the input was a list, this the indicies to remove, otherwise empty List.
      */
-    public abstract List<Integer> applySpec(Object input);
+    public abstract List<Integer> applySpec(List<Object> input);
+
+    /**
+     * @param input Map
+     * @return If the input was a list, this the indicies to remove, otherwise empty List.
+     */
+    public abstract List<String> applySpec(Map<String,Object> input);
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/removr/spec/RemovrSpec.java
@@ -86,14 +86,18 @@ public abstract class RemovrSpec {
     }
 
     /**
-     * @param input List
-     * @return If the input was a list, this the indicies to remove, otherwise empty List.
+     * Build a list of indices to remove from the input list, using the pathElement
+     *  from the Spec.
+     *
+     * @return the indicies to remove, otherwise empty List.
      */
-    public abstract List<Integer> applySpec(List<Object> input);
+    public abstract List<Integer> applyToList( List<Object> inputList );
 
     /**
-     * @param input Map
-     * @return If the input was a list, this the indicies to remove, otherwise empty List.
+     * Build a list of keys to remove from the input map, using the pathElement
+     *  from the Spec.
+     *
+     * @return the keys to remove, otherwise empty List.
      */
-    public abstract List<String> applySpec(Map<String,Object> input);
+    public abstract List<String> applyToMap( Map<String, Object> inputMap );
 }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
@@ -33,10 +33,11 @@ public class RemovrTest {
             {"multiStarSupport"},
             {"starDoublePathElementBoundaryConditions"},
             // Array tests
-            {"array_removeJsonArrayFields"},
-            {"array_nonStarInArrayDoesNotDie"},
             {"array_canPassThruNestedArrays"},
-            {"array_removeAnArrayIndex"}
+            {"array_canHandleTopLevelArray"},
+            {"array_nonStarInArrayDoesNotDie"},
+            {"array_removeAnArrayIndex"},
+            {"array_removeJsonArrayFields"}
         };
     }
 

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/RemovrTest.java
@@ -27,13 +27,16 @@ public class RemovrTest {
     @DataProvider
     public Object[][] getTestCaseNames() {
         return new Object[][] {
-        {"firstSample"},
-        {"boundaryConditions"},
-        {"removrWithWildcardSupport"},
-        {"multiStarSupport"},
-        {"starDoublePathElementBoundaryConditions"},
-        {"removeJsonArrayFields"}
-
+            {"firstSample"},
+            {"boundaryConditions"},
+            {"removrWithWildcardSupport"},
+            {"multiStarSupport"},
+            {"starDoublePathElementBoundaryConditions"},
+            // Array tests
+            {"array_removeJsonArrayFields"},
+            {"array_nonStarInArrayDoesNotDie"},
+            {"array_canPassThruNestedArrays"},
+            {"array_removeAnArrayIndex"}
         };
     }
 

--- a/jolt-core/src/test/resources/json/removr/array_canHandleTopLevelArray.json
+++ b/jolt-core/src/test/resources/json/removr/array_canHandleTopLevelArray.json
@@ -1,0 +1,51 @@
+{
+  "input": [
+    [
+      {
+        "removeThis": "gone",
+        "testStay": "firstArray"
+      },
+      {
+        "removeThis": "gone",
+        "testStay": "still here firstArray"
+      }
+    ],
+    [
+      {
+        "removeThis": "gone",
+        "testStay": "secondaryArray"
+      },
+      {
+        "removeThis": "gone",
+        "testStay": "still here secondArray"
+      }
+    ]
+  ],
+
+  "spec": {
+    "*": {
+      "*" : {
+        "removeThis": ""
+      }
+    }
+  },
+
+  "expected": [
+    [
+      {
+        "testStay": "firstArray"
+      },
+      {
+        "testStay": "still here firstArray"
+      }
+    ],
+    [
+      {
+        "testStay": "secondaryArray"
+      },
+      {
+        "testStay": "still here secondArray"
+      }
+    ]
+  ]
+}

--- a/jolt-core/src/test/resources/json/removr/array_canPassThruNestedArrays.json
+++ b/jolt-core/src/test/resources/json/removr/array_canPassThruNestedArrays.json
@@ -1,0 +1,57 @@
+{
+  "input": {
+    "arrayObjects": [
+      [
+        {
+          "removeThis": "gone",
+          "testStay": "firstArray"
+        },
+        {
+          "removeThis": "gone",
+          "testStay": "still here firstArray"
+        }
+      ],
+      [
+        {
+          "removeThis": "gone",
+          "testStay": "secondaryArray"
+        },
+        {
+          "removeThis": "gone",
+          "testStay": "still here secondArray"
+        }
+      ]
+    ]
+  },
+
+  "spec": {
+    "arrayObjects": {
+      "*": {
+        "*" : {
+          "removeThis": ""
+        }
+      }
+    }
+  },
+
+  "expected": {
+    "arrayObjects": [
+      [
+        {
+          "testStay": "firstArray"
+        },
+        {
+          "testStay": "still here firstArray"
+        }
+      ],
+      [
+        {
+          "testStay": "secondaryArray"
+        },
+        {
+          "testStay": "still here secondArray"
+        }
+      ]
+    ]
+  }
+}

--- a/jolt-core/src/test/resources/json/removr/array_nonStarInArrayDoesNotDie.json
+++ b/jolt-core/src/test/resources/json/removr/array_nonStarInArrayDoesNotDie.json
@@ -1,36 +1,36 @@
 {
   "input": {
-
     "arrayObjects": [
       {
-        "removeThis": "gone",
+        "a": "b",
         "testStay": "here"
       },
       {
-        "removeThis": "remove",
+        "a": "b",
         "testStay": "still here"
       }
-    ],
-    "arrayString" : ["entire", "field", "gone"]
+    ]
   },
 
   "spec": {
-
     "arrayObjects": {
-      "*": {
-        "removeThis": ""
+      "pants": {
+        "a": ""
+      },
+      "abc*" : {
+        "a": ""
       }
-    },
-    "arrayString": ""
-
+    }
   },
 
   "expected": {
     "arrayObjects": [
       {
+        "a": "b",
         "testStay": "here"
       },
       {
+        "a": "b",
         "testStay": "still here"
       }
     ]

--- a/jolt-core/src/test/resources/json/removr/array_removeAnArrayIndex.json
+++ b/jolt-core/src/test/resources/json/removr/array_removeAnArrayIndex.json
@@ -13,8 +13,13 @@
     "arrayObjects": {
       "0" : "",  // test lower bound
       "2" : "",
-      "4" : ""   // test upper bound of list
-    }
+      "4" : "",   // test upper bound of list
+
+      // Things that should not cause errors / problems
+      "10": "",   // Index larger than input array
+      "-8": "",   // Index value is negative
+      "a" : ""    // Index value is not a number
+      }
   },
 
   "expected": {

--- a/jolt-core/src/test/resources/json/removr/array_removeAnArrayIndex.json
+++ b/jolt-core/src/test/resources/json/removr/array_removeAnArrayIndex.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "arrayObjects": [
+      { "zero":  "ZERO" },
+      { "one":   "ONE" },
+      { "two":   2 },
+      { "three": 3 },
+      { "four":  "FOUR" }
+    ]
+  },
+
+  "spec": {
+    "arrayObjects": {
+      "0" : "",  // test lower bound
+      "2" : "",
+      "4" : ""   // test upper bound of list
+    }
+  },
+
+  "expected": {
+    "arrayObjects": [
+      { "one":   "ONE" },
+      { "three": 3 }
+    ]
+  }
+}

--- a/jolt-core/src/test/resources/json/removr/array_removeJsonArrayFields.json
+++ b/jolt-core/src/test/resources/json/removr/array_removeJsonArrayFields.json
@@ -1,0 +1,35 @@
+{
+  "input": {
+    "arrayObjects": [
+      {
+        "removeThis": "gone",
+        "testStay": "here"
+      },
+      {
+        "removeThis": "remove",
+        "testStay": "still here"
+      }
+    ],
+    "arrayString" : ["entire", "field", "gone"]
+  },
+
+  "spec": {
+    "arrayObjects": {
+      "*": {
+        "removeThis": ""
+      }
+    },
+    "arrayString": ""
+  },
+
+  "expected": {
+    "arrayObjects": [
+      {
+        "testStay": "here"
+      },
+      {
+        "testStay": "still here"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Heavy Refactoring on Remover. 
- More tests, and they pass
 - Need to make a pass a documentation.

It can now pretty much fully handle arrays.
 - recursing thru them
 - removing specific array indices

Also fixed #133 by renaming a package.
 - bazarvoice -> bazaarvoice.