### PR TITLE
Can escape the "." character in Shiftr now

### DIFF
--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
@@ -55,6 +55,7 @@ public class ShiftrTest {
             {"prefixedData"},
             {"prefixSoupToBuckets"},
             {"queryMappingXform"},
+            {"simpleRHSEscape"},
             {"singlePlacement"},
             {"specialKeys"},
             {"transposeArrayContents1"},

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/spec/RHSParsingTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/spec/RHSParsingTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.shiftr.spec;
+
+import com.google.common.collect.Lists;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class RHSParsingTest {
+
+    @DataProvider
+    public Object[][] RHSParsingTests() throws IOException {
+        return new Object[][] {
+            {
+                "simple, no escape",
+                "a.b.c",
+                Arrays.asList( "a", "b", "c" ),
+            },
+            {
+                "ref and array, no escape",
+                "a.&(1,2).[]",
+                Arrays.asList( "a", "&(1,2)", "[]" )
+            },
+            {
+                "single transpose, no escape",
+                "a.@(l.m.n).c",
+                Arrays.asList( "a", "@(l.m.n)", "c" )
+            },
+            {
+                "non-special char escape passes thru",
+                "a\\\\bc.def",
+                Arrays.asList( "a\\bc", "def" )
+            },
+            {
+                "single escape",
+                "a\\.b.c",
+                Arrays.asList( "a.b", "c" )
+            },
+            {
+                "double escape in front of a period, does not escape the period",
+                "a\\\\.b.c",
+                Arrays.asList( "a\\", "b", "c" )
+            },
+            {
+                "@Class example",
+                "a.@Class.c",
+                Arrays.asList( "a", "@(Class)", "c" )
+            }
+        };
+    }
+
+    @Test(dataProvider = "RHSParsingTests" )
+    public void testRHSParsing( String testName, String unSweetendDotNotation, List<String> expected ) {
+
+        List<String> actual = ShiftrSpec.parseDotNotation( Lists.<String>newArrayList(), ShiftrSpec.stringIterator(unSweetendDotNotation), unSweetendDotNotation );
+
+        Assert.assertEquals( actual, expected, "Failed test name " + testName );
+    }
+}

--- a/jolt-core/src/test/resources/json/shiftr/simpleRHSEscape.json
+++ b/jolt-core/src/test/resources/json/shiftr/simpleRHSEscape.json
@@ -1,0 +1,57 @@
+{
+    "input": {
+        "rating": {
+            "primary": {
+                "value": 4,
+                "max": 5
+            },
+            "quality": {
+                "value": 3,
+                "max": 7
+            }
+        },
+
+        // Test if we process input data with a "." in it
+        "foo.bar" : "baz",
+
+        // Test if we can use the @ transpose operator to get to the "baz" value above
+        "test" : {
+            "use_as_data" : "data",
+            "use_as_path" : "path"
+        }
+    },
+
+    "spec": {
+        "rating": {
+            "primary": {
+                // escape the '.' so that an output key can have a dot in it
+                "value": "data.rating\\.primary"
+            },
+            "*": {
+                "value": "data.rating\\.&1"
+            }
+        },
+
+        "foo.bar" : "foobar",
+        "test" : {
+            "use_as_data" : {
+                "data" : {
+                    "@(3,foo\\.bar)" : "test.data"
+                }
+            },
+            "use_as_path" : "test.@(2,foo\\.bar)"
+        }
+    },
+
+    "expected": {
+        "data" : {
+            "rating.primary": 4,
+            "rating.quality": 3
+        },
+        "foobar" : "baz",
+        "test": {
+            "data" : "baz",
+            "baz": "path"
+        }
+    }
+}


### PR DESCRIPTION
So that you can have output paths like "ref.local" that do not have that be nested maps.

Example, RHS Shiftr values, and how they would manifest in the ouput tree
* "data.ref.local" --> { "data" : { "ref" : { "local" : X } } }
* "data.ref\\.local" --> { "data" : { "ref.local" : X } }

Escaped "." can also be used in the "@" transpose operator.

Fixes #153
Fixes #134, well the first part of it