### PR TITLE
Ability to use a @ transpose operation from inside an array lookup.

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrSpec.java
@@ -89,7 +89,14 @@ public abstract class ShiftrSpec {
         else if ( "*".equals( key ) ) {
             return new StarAllPathElement( key );
         }
+        else if ( key.startsWith( "[" ) ) {
 
+            if ( StringTools.countMatches(key, "[") != 1 || StringTools.countMatches(key, "]") != 1 ) {
+                throw new SpecException( "Invalid key:" + key + " has too many [] references.");
+            }
+
+            return new ArrayPathElement( key );
+        }
         //// LHS multiple values
         else if ( key.startsWith("@") || key.contains( "@(" ) ) {
             return TransposePathElement.parse( key );
@@ -312,8 +319,13 @@ public abstract class ShiftrSpec {
             if( c == '@' ) {
                 sb.append( '@' );
                 sb.append( parseAtPathElement( iter, dotNotationRef ) );
-                pathStrings.add( sb.toString() );
-                sb = new StringBuilder();
+
+                //                      there was a "[" seen       but no "]"
+                boolean isPartOfArray = sb.indexOf( "[" ) != -1 && sb.indexOf( "]" ) == -1;
+                if ( ! isPartOfArray ) {
+                    pathStrings.add( sb.toString() );
+                    sb = new StringBuilder();
+                }
             }
             else if ( c == '.' ) {
                 if ( escapeActive ) {

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
@@ -68,6 +68,7 @@ public class ShiftrTest {
             {"transposeComplex6_rhs-complex-at"},
             {"transposeComplex7_coerce-int-string-conversion"},
             {"transposeComplex8_coerce-boolean-string-conversion"},
+            {"transposeComplex9_lookup_an_array_index"},
             {"transposeInverseMap1"},
             {"transposeInverseMap2"},
             {"transposeLHS1"},

--- a/jolt-core/src/test/resources/json/shiftr/transposeComplex9_lookup_an_array_index.json
+++ b/jolt-core/src/test/resources/json/shiftr/transposeComplex9_lookup_an_array_index.json
@@ -1,0 +1,40 @@
+{
+    "input": {
+        "clients" : {
+            "Acme" : {
+                "clientId": "Acme",
+                "index" : 1
+            },
+            "Axe" : {
+                "clientId": "AXE",
+                "index" : 0
+            },
+            "Bob's Burgers" : {
+                "clientId": "BBurgers",
+
+                // the idea here is that index is non-numeric and non-coercible to numeric
+                // in this case Shiftr will just ignore the output, thus preventing "BBurgers" from getting to the output
+                "index" : "abc"
+            },
+            "PhoVan" : {
+                "clientId": "pho",
+
+                // the idea here is that the index is a String, but is coercible to numeric
+                "index" : "3"
+            }
+        }
+    },
+
+    "spec": {
+        "clients" : {
+            "*": {
+                // test the abilyt to lookup the numeric index using a @ / Transpose operator, aka [@(1,index)]
+                "clientId": "clientIdArray[@(1,index)]"
+            }
+        }
+    },
+
+    "expected": {
+        "clientIdArray" : [ "AXE", "Acme", null, "pho" ]
+    }
+}


### PR DESCRIPTION
The idea is that if your input data has the index position of data explicitly mapped, you should be able to lookup it up.

Example
```
"clients" : {
   "Acme" : {
       "clientId": "ACME",
       "index" : 1
     }
}
```
You want to be able to use the "index" to write the sibling property of clientId to an output array, like so :
```
"clientIdArray[@(1,index)]"
```