### PR TITLE
Ability to Shift data to the "trash".

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
@@ -61,6 +61,10 @@ public class ShiftrLeafSpec extends ShiftrSpec {
                 writers.add( parseOutputDotNotation( dotNotation ) );
             }
         }
+        else if ( rhs == null ) {
+            // this means someone wanted to match something, but not send it anywhere.  Basically like a removal.
+            writers = Collections.emptyList();
+        }
         else {
             throw new SpecException( "Invalid Shiftr spec RHS.  Should be map, string, or array of strings.  Spec in question : " + rhs );
         }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
@@ -55,6 +55,7 @@ public class ShiftrTest {
             {"prefixedData"},
             {"prefixSoupToBuckets"},
             {"queryMappingXform"},
+            {"shiftToTrash"},
             {"simpleRHSEscape"},
             {"singlePlacement"},
             {"specialKeys"},

--- a/jolt-core/src/test/resources/json/shiftr/shiftToTrash.json
+++ b/jolt-core/src/test/resources/json/shiftr/shiftToTrash.json
@@ -1,0 +1,28 @@
+{
+    "input": {
+        "a" : "a",
+        "b" : "b",
+        "c" : "c",
+        "d" : "d"
+    },
+
+    "spec": {
+
+        // The idea here is that I want to send everything BUT the "c" input to "foo.&".
+        //
+        // The way to do that is to specify the "c" key, but have it's RHS output path be null.
+        // Shiftr will then match the literal "c" (and not do anything with it's input) before
+        //  it matches the rest of the input keys with the "*", thus accomplishing the goal.
+        //
+        "*" : "foo.&",
+        "c" : null
+    },
+
+    "expected": {
+        "foo" : {
+            "a" : "a",
+            "b" : "b",
+            "d" : "d"
+        }
+    }
+}


### PR DESCRIPTION
There are often cases where you want to shift a bunch of data using the "*" wild card, except for a few well known values.

Now you can just "blacklist" those values, by enumerating them in the Shiftr spec, but have their output path be null.