### PR TITLE
Shiftr Array logic handles negative numbers better now.

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/pathelement/ArrayPathElement.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/pathelement/ArrayPathElement.java
@@ -72,15 +72,13 @@ public class ArrayPathElement extends BasePathElement implements MatchablePathEl
                 canonicalForm = "[" + tpe.getCanonicalForm() + "]";
             }
             else {
-                try {
-                    Integer.parseInt( meat );
+                aI = verifyStringIsNonNegativeInteger(meat);
+                if ( aI != null ) {
                     apt = ArrayPathType.EXPLICIT_INDEX;
-
-                    canonicalForm = "[" + meat + "]";
-                    aI = meat;
+                    canonicalForm = "[" + aI + "]";
                 }
-                catch ( NumberFormatException nfe ){
-                    throw new SpecException( "Unable to parse explicit array index of:" + meat + " from key:" + key );
+                else {
+                    throw new SpecException( "Bad explict array index:" + meat + " from key:" + key );
                 }
             }
         }
@@ -114,7 +112,7 @@ public class ArrayPathElement extends BasePathElement implements MatchablePathEl
 
             case TRANSPOSE:
                 String key = transposePathElement.evaluate( walkedPath );
-                return verifyStringIsInteger( key );
+                return verifyStringIsNonNegativeInteger( key );
 
             case REFERENCE:
                 LiteralPathElement lpe = walkedPath.elementFromEnd( ref.getPathIndex() ).getLiteralPathElement();
@@ -127,17 +125,25 @@ public class ArrayPathElement extends BasePathElement implements MatchablePathEl
                     keyPart = lpe.getSubKeyRef( 0 );
                 }
 
-                return verifyStringIsInteger( keyPart );
+                return verifyStringIsNonNegativeInteger( keyPart );
             default:
                 throw new IllegalStateException( "ArrayPathType enum added two without updating this switch statement." );
         }
     }
 
-    private static String verifyStringIsInteger( String key ) {
+    /**
+     * @return the String version of a non-Negative integer, else null
+     */
+    private static String verifyStringIsNonNegativeInteger( String key ) {
         try
         {
-            Integer.parseInt( key );
-            return key;
+            int number = Integer.parseInt( key );
+            if ( number >= 0 ) {
+                return key;
+            }
+            else {
+                return null;
+            }
         }
         catch ( NumberFormatException nfe ) {
             // Jolt should not throw any exceptions just because the input data does not match what is expected.

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/ShiftrUnitTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/ShiftrUnitTest.java
@@ -102,35 +102,39 @@ public class ShiftrUnitTest {
             },
             {
                     "Empty sub-spec",
-                    JsonUtils.jsonToMap( "{ \"tuna\" : {} }" ),
+                    JsonUtils.javason( "{ 'tuna' : {} }" ),
             },
             {
                     "Bad @",
-                    JsonUtils.jsonToMap( "{ \"tuna-*-marlin-*\" : { \"rating-@\" : \"&(1,2).&.value\" } }" ),
+                    JsonUtils.javason( "{ 'tuna-*-marlin-*' : { 'rating-@' : '&(1,2).&.value' } }" ),
             },
             {
                     "RHS @ by itself",
-                    JsonUtils.jsonToMap( "{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"&(1,2).@.value\" } }" ),
+                    JsonUtils.javason( "{ 'tuna-*-marlin-*' : { 'rating-*' : '&(1,2).@.value' } }" ),
             },
             {
                     "RHS @ with bad Parens",
-                    JsonUtils.jsonToMap( "{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"&(1,2).@(data.&(1,1).value\" } }" ),
+                    JsonUtils.javason( "{ 'tuna-*-marlin-*' : { 'rating-*' : '&(1,2).@(data.&(1,1).value' } }" ),
             },
             {
                     "RHS *",
-                    JsonUtils.jsonToMap( "{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"&(1,2).*.value\" } }" ),
+                    JsonUtils.javason( "{ 'tuna-*-marlin-*' : { 'rating-*' : '&(1,2).*.value' } }" ),
             },
             {
                     "RHS $",
-                    JsonUtils.jsonToMap( "{ \"tuna-*-marlin-*\" : { \"rating-*\" : \"&(1,2).$.value\" } }" ),
+                    JsonUtils.javason( "{ 'tuna-*-marlin-*' : { 'rating-*' : '&(1,2).$.value' } }" ),
             },
             {
                     "Two Arrays",
-                    JsonUtils.jsonToMap("{ \"tuna-*-marlin-*\" : { \"rating-*\" : [ \"&(1,2).photos[&(0,1)]-subArray[&(1,2)].value\", \"foo\"] } }"),
+                    JsonUtils.javason("{ 'tuna-*-marlin-*' : { 'rating-*' : [ '&(1,2).photos[&(0,1)]-subArray[&(1,2)].value', 'foo'] } }"),
             },
             {
                     "Can't mix * and & in the same key",
-                    JsonUtils.jsonToMap("{ \"tuna-*-marlin-*\" : { \"rating-&(1,2)-*\" : [ \"&(1,2).value\", \"foo\"] } }"),
+                    JsonUtils.javason("{ 'tuna-*-marlin-*' : { 'rating-&(1,2)-*' : [ '&(1,2).value', 'foo'] } }"),
+            },
+            {
+                    "Don't put negative numbers in array references",
+                    JsonUtils.javason("{ 'tuna' : 'marlin[-1]' }"),
             }
         };
     }

--- a/jolt-core/src/test/resources/json/shiftr/transposeComplex9_lookup_an_array_index.json
+++ b/jolt-core/src/test/resources/json/shiftr/transposeComplex9_lookup_an_array_index.json
@@ -21,6 +21,18 @@
 
                 // the idea here is that the index is a String, but is coercible to numeric
                 "index" : "3"
+            },
+            "Weyland-Yutani" : {
+                "clientId": "Walmart",
+
+                // the idea here is that negative index values get ignored
+                "index" : -1
+            },
+            "UmbrellaCorporation" : {
+                "clientId": "Monsanto",
+
+                // the idea here is that negative index values get ignored
+                "index" : "-2"
             }
         }
     },


### PR DESCRIPTION
If literal part of spec, throws a SpecException.
If due to input lookup, just ignores it and skips that operation.

Fixes #155