### PR TITLE
Ability to continue to Shift after a Transpose element.

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/Optional.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/Optional.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.common;
+
+/**
+ * This can go away when Jolt moves to Java 8 and can use the Java 8 Optional.
+ */
+public class Optional<T> {
+
+    private final T obj;
+    private final boolean abs;
+
+    private static final Optional<?> EMPTY = new Optional<>();
+
+    public static<T> Optional<T> empty() {
+        @SuppressWarnings("unchecked")
+        Optional<T> t = (Optional<T>) EMPTY;
+        return t;
+    }
+
+    public static <T> Optional<T> of(T value) {
+        return new Optional<>(value);
+    }
+
+    private Optional() {
+        obj = null;
+        abs = true;
+    }
+
+    private Optional( T obj ) {
+        this.obj = obj;
+        abs = false;
+    }
+
+    public T get() {
+        return obj;
+    }
+
+    public boolean isPresent() {
+        return ! abs;
+    }
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/PathEvaluatingTraversal.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/PathEvaluatingTraversal.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.shiftr;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.common.WalkedPath;
 import com.bazaarvoice.jolt.common.pathelement.EvaluatablePathElement;
 import com.bazaarvoice.jolt.common.pathelement.PathElement;
@@ -96,11 +97,12 @@ public abstract class PathEvaluatingTraversal {
         }
     }
 
-    public Object read( Object data, WalkedPath walkedPath ) {
+    public Optional<Object> read( Object data, WalkedPath walkedPath ) {
         List<String> evaledPaths = evaluate( walkedPath );
         if ( evaledPaths == null ) {
-            return null;
+            return Optional.empty();
         }
+
         return traversr.get( data, evaledPaths );
     }
 

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/ShiftrTraversr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/ShiftrTraversr.java
@@ -18,13 +18,14 @@ package com.bazaarvoice.jolt.shiftr;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.SimpleTraversr;
 import com.bazaarvoice.jolt.traversr.traversal.TraversalStep;
 
 /**
  * Traverser that does not overwrite data.
  */
-public class ShiftrTraversr extends SimpleTraversr {
+public class ShiftrTraversr<DataType> extends SimpleTraversr<DataType> {
 
     public ShiftrTraversr( String humanPath ) {
         super( humanPath );
@@ -41,27 +42,27 @@ public class ShiftrTraversr extends SimpleTraversr {
      *  3) if there something other than a list there, grab it and stuff it and the data into a list
      *     and overwrite what is there with a list.
      */
-    public Object handleFinalSet( TraversalStep traversalStep, Object tree, String key, Object data ) {
+    public Optional<DataType> handleFinalSet( TraversalStep traversalStep, Object tree, String key, DataType data ) {
 
-        Object sub = traversalStep.get( tree, key );
+        Optional<DataType> optSub = traversalStep.get( tree, key );
 
-        if ( sub == null ) {
+        if ( !optSub.isPresent() || optSub.get() == null ) {
             // nothing is here so just set the data
             traversalStep.overwriteSet( tree, key, data );
         }
-        else if ( sub instanceof List ) {
+        else if ( optSub.get() instanceof List ) {
             // there is a list here, so we just add to it
-            ((List<Object>) sub).add( data );
+            ((List<Object>) optSub.get()).add( data );
         }
         else {
             // take whatever is there and make it the first element in an Array
             List<Object> temp = new ArrayList<>();
-            temp.add( sub );
+            temp.add( optSub.get() );
             temp.add( data );
 
             traversalStep.overwriteSet( tree, key, temp );
         }
 
-        return data;
+        return Optional.of( data );
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrCompositeSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrCompositeSpec.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.shiftr.spec;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.common.pathelement.*;
 import com.bazaarvoice.jolt.exception.SpecException;
 import com.bazaarvoice.jolt.common.WalkedPath;
@@ -166,6 +167,22 @@ public class ShiftrCompositeSpec extends ShiftrSpec {
         LiteralPathElement thisLevel = pathElement.match( inputKey, walkedPath );
         if ( thisLevel == null ) {
             return false;
+        }
+
+        // If we are a TransposePathElement, try to swap the "input" with what we lookup from the Transpose
+        if ( pathElement instanceof TransposePathElement ) {
+
+            TransposePathElement tpe = (TransposePathElement) this.pathElement;
+
+            // Note the data found may not be a String, thus we have to call the special objectEvaluate
+            // Optional, because the input data could have been a valid null.
+            Optional<Object> optional = tpe.objectEvaluate( walkedPath );
+            if ( optional.isPresent() ) {
+                input = optional.get();
+            }
+            else {
+                return false;
+            }
         }
 
         // add ourselves to the path, so that our children can reference us

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/shiftr/spec/ShiftrLeafSpec.java
@@ -16,6 +16,7 @@
 package com.bazaarvoice.jolt.shiftr.spec;
 
 import com.bazaarvoice.jolt.Shiftr;
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.common.pathelement.HashPathElement;
 import com.bazaarvoice.jolt.common.pathelement.TransposePathElement;
 import com.bazaarvoice.jolt.shiftr.ShiftrWriter;
@@ -124,8 +125,11 @@ public class ShiftrLeafSpec extends ShiftrSpec {
             TransposePathElement tpe = (TransposePathElement) this.pathElement;
 
             // Note the data found may not be a String, thus we have to call the special objectEvaluate
-            data = tpe.objectEvaluate( walkedPath );
-            if ( data == null ) {
+            Optional<Object> evaledData = tpe.objectEvaluate( walkedPath );
+            if ( evaledData.isPresent() ) {
+                data = evaledData.get();
+            }
+            else {
                 // if we could not find the value we want looking down the tree, bail
                 return false;
             }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/SimpleTraversal.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/SimpleTraversal.java
@@ -15,6 +15,8 @@
  */
 package com.bazaarvoice.jolt.traversr;
 
+import com.bazaarvoice.jolt.common.Optional;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +33,7 @@ import java.util.List;
  *  objects of the same type to the tree, therefore this class can take a generic
  *  parameter "K" to reduce casting.
  */
-public class SimpleTraversal<K> {
+public class SimpleTraversal<DataType> {
 
     private final SimpleTraversr traversr;
     private final List<String> keys;
@@ -66,8 +68,8 @@ public class SimpleTraversal<K> {
      * @param tree tree of Map and List JSON structure to navigate
      * @return the object you wanted, or null if the object or any step along the path to it were not there
      */
-    public K get( Object tree ) {
-        return (K) traversr.get( tree, keys );
+    public Optional<DataType> get( Object tree ) {
+        return (Optional<DataType>) traversr.get( tree, keys );
     }
 
     /**
@@ -75,15 +77,15 @@ public class SimpleTraversal<K> {
      * @param data JSON style data object you want to set
      * @return returns the data object if successfully set, otherwise null if there was a problem walking the path
      */
-    public K set( Object tree, K data ) {
-        return (K) traversr.set( tree, keys, data );
+    public Optional<DataType> set( Object tree, DataType data ) {
+        return (Optional<DataType>) traversr.set( tree, keys, data );
     }
 
     /**
      * @param tree tree of Map and List JSON structure to navigate
      * @return removes and returns the data object if it was able to successfully navigate to it and remove it.
      */
-    public K remove( Object tree ) {
-        return (K) traversr.remove( tree, keys );
+    public Optional<DataType> remove( Object tree ) {
+        return traversr.remove( tree, keys );
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/SimpleTraversr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/SimpleTraversr.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.traversr;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.traversal.TraversalStep;
 
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.List;
  * 1 Does overwrite sets at the leaf level
  * 2 Will create intermediate container objects only on SET operations
  */
-public class SimpleTraversr extends Traversr {
+public class SimpleTraversr<DataType> extends Traversr<DataType> {
 
     public SimpleTraversr( String humanPath ) {
         super( humanPath );
@@ -36,7 +37,7 @@ public class SimpleTraversr extends Traversr {
     }
 
     @Override
-    public Object handleFinalSet( TraversalStep traversalStep, Object tree, String key, Object data ) {
+    public Optional<DataType> handleFinalSet( TraversalStep traversalStep, Object tree, String key, DataType data ) {
         return traversalStep.overwriteSet( tree, key, data );
     }
 
@@ -44,9 +45,11 @@ public class SimpleTraversr extends Traversr {
      * Only make a new instance of a container object for SET, if there is nothing "there".
      */
     @Override
-    public Object handleIntermediateGet( TraversalStep traversalStep, Object tree, String key, TraversalStep.Operation op ) {
+    public Optional<DataType> handleIntermediateGet( TraversalStep traversalStep, Object tree, String key, TraversalStep.Operation op ) {
 
-        Object sub = traversalStep.get( tree, key );
+        Optional<Object> optSub = traversalStep.get( tree, key );
+
+        Object sub = optSub.get();
 
         if ( sub == null && op == TraversalStep.Operation.SET ) {
 
@@ -55,6 +58,6 @@ public class SimpleTraversr extends Traversr {
             traversalStep.overwriteSet( tree, key, sub );
         }
 
-        return sub;
+        return Optional.of( (DataType) sub );
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/Traversr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/Traversr.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.traversr;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.traversal.ArrayTraversalStep;
 import com.bazaarvoice.jolt.traversr.traversal.AutoExpandArrayTraversalStep;
 import com.bazaarvoice.jolt.traversr.traversal.MapTraversalStep;
@@ -55,7 +56,7 @@ import java.util.List;
  *
  * The list of keys are all Strings, which ArrayTraversals will convert to Integers as needed.
  */
-public abstract class Traversr {
+public abstract class Traversr<DataType> {
 
     private final TraversalStep root;
     private final int traversalLength;
@@ -109,20 +110,16 @@ public abstract class Traversr {
     }
 
     /**
+     * TODO : Make this use the Java 8 optional, when Jolt moves to 8
+     *
      * Note : Calling this method MAY modify the tree object by adding new Maps and Lists as needed
      *  for the traversal.  This is determined by the behavior of the implementations of the
      *  abstract methods of this class.
-     *
-     * @return null or data
      */
-    public Object get( Object tree, List<String> keys ) {
+    public Optional<DataType> get( Object tree, List<String> keys ) {
 
         if ( keys.size() != traversalLength ) {
             throw new TraversrException( "Traversal Path and number of keys mismatch, traversalLength:" + traversalLength + " numKeys:" + keys.size() );
-        }
-
-        if ( tree == null ) {
-            return null;
         }
 
         return root.traverse( tree, TraversalStep.Operation.GET, keys.iterator(), null );
@@ -133,7 +130,7 @@ public abstract class Traversr {
      * @param data JSON style data object you want to set
      * @return returns the data object if successfully set, otherwise null if there was a problem walking the path
      */
-    public Object set( Object tree, List<String> keys, Object data ) {
+    public Optional<DataType> set( Object tree, List<String> keys, DataType data ) {
 
         if ( keys.size() != traversalLength ) {
             throw new TraversrException( "Traversal Path and number of keys mismatch, traversalLength:" + traversalLength + " numKeys:" + keys.size() );
@@ -147,7 +144,7 @@ public abstract class Traversr {
            All we return is a reference to the data, if we were successful in our set.
         */
         if ( tree == null ) {
-            return null;
+            return Optional.empty();
         }
 
         return root.traverse( tree, TraversalStep.Operation.SET, keys.iterator(), data );
@@ -157,17 +154,15 @@ public abstract class Traversr {
      * Note : Calling this method MAY modify the tree object by adding new Maps and Lists as needed
      *  for the traversal.  This is determined by the behavior of the implementations of the
      *  abstract methods of this class.
-     *
-     * @return null or data
      */
-    public Object remove( Object tree, List<String> keys ) {
+    public Optional<DataType> remove( Object tree, List<String> keys ) {
 
         if ( keys.size() != traversalLength ) {
             throw new TraversrException( "Traversal Path and number of keys mismatch, traversalLength:" + traversalLength + " numKeys:" + keys.size() );
         }
 
         if ( tree == null ) {
-            return null;
+            return Optional.empty();
         }
 
         return root.traverse( tree, TraversalStep.Operation.REMOVE, keys.iterator(), null );
@@ -184,7 +179,7 @@ public abstract class Traversr {
      *
      * @return the data object if the set was successful, or null if not
      */
-    public abstract Object handleFinalSet( TraversalStep traversalStep, Object tree, String key, Object data );
+    public abstract Optional<DataType> handleFinalSet( TraversalStep traversalStep, Object tree, String key, DataType data );
 
     /**
      * Allow subclasses to control how gets are handled for intermediate traversals.
@@ -194,8 +189,6 @@ public abstract class Traversr {
      *   a data type incompatible with our child Traversal, what do we do?
      *
      * Overwrite or just return?
-     *
-     * @return null or a container object (Map/List) for our child Traversal to use
      */
-    public abstract Object handleIntermediateGet( TraversalStep traversalStep, Object tree, String key, Operation op );
+    public abstract Optional<DataType> handleIntermediateGet( TraversalStep traversalStep, Object tree, String key, Operation op );
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/ArrayTraversalStep.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/ArrayTraversalStep.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.traversr.traversal;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.Traversr;
 
 import java.util.ArrayList;
@@ -23,7 +24,7 @@ import java.util.List;
 /**
  * TraversalStep that expects to handle List objects.
  */
-public class ArrayTraversalStep extends BaseTraversalStep<List<Object>> {
+public class ArrayTraversalStep<DataType> extends BaseTraversalStep<List<Object>, DataType> {
 
     public ArrayTraversalStep( Traversr traversr, TraversalStep child ) {
         super( traversr, child );
@@ -33,41 +34,40 @@ public class ArrayTraversalStep extends BaseTraversalStep<List<Object>> {
         return List.class;
     }
 
-    public Object newContainer() {
+    public List<Object> newContainer() {
         return new ArrayList<>();
     }
 
     @Override
-    public Object get( List<Object> list, String key ) {
+    public Optional<DataType> get( List<Object> list, String key ) {
 
         int arrayIndex = Integer.parseInt( key );
         if ( arrayIndex < list.size() ) {
-            return list.get( arrayIndex );
+            return Optional.of( (DataType) list.get( arrayIndex ) );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override
-    public Object remove( List<Object> list, String key ) {
+    public Optional<DataType> remove( List<Object> list, String key ) {
 
         int arrayIndex = Integer.parseInt( key );
         if ( arrayIndex < list.size() ) {
-            return list.remove( arrayIndex );
+            return Optional.of( (DataType) list.remove( arrayIndex ) );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override
-    public Object overwriteSet( List<Object> list, String key, Object data ) {
+    public Optional<DataType> overwriteSet( List<Object> list, String key, DataType data ) {
 
         int arrayIndex = Integer.parseInt( key );
         ensureArraySize( list, arrayIndex );            // make sure it is big enough
         list.set( arrayIndex, data );
-        return data;
+        return Optional.of( data );
     }
-
 
     private static void ensureArraySize( List<Object> list, Integer upperIndex ) {
         for ( int sizing = list.size(); sizing <= upperIndex; sizing++ ) {

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/AutoExpandArrayTraversalStep.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/AutoExpandArrayTraversalStep.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.traversr.traversal;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.Traversr;
 import com.bazaarvoice.jolt.traversr.TraversrException;
 
@@ -33,40 +34,40 @@ import java.util.List;
  *   We want the value of marlin to always be a list, and anytime we set data
  *   to marlin, it should just be added to the list.
  */
-public class AutoExpandArrayTraversalStep extends ArrayTraversalStep {
+public class AutoExpandArrayTraversalStep<DataType> extends ArrayTraversalStep<DataType> {
 
     public AutoExpandArrayTraversalStep( Traversr traversr, TraversalStep child ) {
         super( traversr, child );
     }
 
     @Override
-    public Object get( List<Object> list, String key ) {
+    public Optional<DataType> get( List<Object> list, String key ) {
 
         if ( ! "[]".equals( key ) ) {
             throw new TraversrException( "AutoExpandArrayTraversal expects a '[]' key. Was: " + key );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override
-    public Object remove( List<Object> list, String key ) {
+    public Optional<DataType> remove( List<Object> list, String key ) {
 
         if ( ! "[]".equals( key ) ) {
             throw new TraversrException( "AutoExpandArrayTraversal expects a '[]' key. Was: " + key );
         }
 
-        return null;
+        return Optional.empty();
     }
 
     @Override
-    public Object overwriteSet( List<Object> list, String key, Object data ) {
+    public Optional<DataType> overwriteSet( List<Object> list, String key, DataType data ) {
 
         if ( ! "[]".equals( key ) ) {
             throw new TraversrException( "AutoExpandArrayTraversal expects a '[]' key. Was: " + key );
         }
 
         list.add( data );
-        return data;
+        return Optional.of( data );
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/BaseTraversalStep.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/BaseTraversalStep.java
@@ -15,12 +15,13 @@
  */
 package com.bazaarvoice.jolt.traversr.traversal;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.Traversr;
 
 import java.util.Iterator;
 
 
-public abstract class BaseTraversalStep<T> implements TraversalStep<T> {
+public abstract class BaseTraversalStep<StepType,DataType> implements TraversalStep<StepType,DataType> {
 
     protected final TraversalStep child;
     protected final Traversr traversr;
@@ -34,10 +35,10 @@ public abstract class BaseTraversalStep<T> implements TraversalStep<T> {
         return child;
     }
 
-    public final Object traverse( Object tree, Operation op, Iterator<String> keys, Object data ) {
+    public final Optional<DataType> traverse( StepType tree, Operation op, Iterator<String> keys, DataType data ) {
 
         if ( tree == null ) {
-            return null;
+            return Optional.empty();
         }
 
         if ( getStepType().isAssignableFrom( tree.getClass() ) ) {
@@ -48,11 +49,11 @@ public abstract class BaseTraversalStep<T> implements TraversalStep<T> {
                 // End of the Traversal so do the set or get
                 switch (op) {
                     case GET :
-                        return this.get( (T) tree, key );
+                        return this.get( tree, key );
                     case SET :
-                        return traversr.handleFinalSet( this, tree, key, data );
+                        return (Optional<DataType>) traversr.handleFinalSet( this, tree, key, data );
                     case REMOVE:
-                        return this.remove( (T) tree, key );
+                        return this.remove( tree, key );
                     default :
                         throw new IllegalStateException( "Invalid op:" + op.toString() );
                 }
@@ -60,19 +61,14 @@ public abstract class BaseTraversalStep<T> implements TraversalStep<T> {
             else {
 
                 // We just an intermediate step, so traverse and then hand over control to our child
-                Object sub = traversr.handleIntermediateGet( this, tree, key, op );
+                Optional<Object> optSub = traversr.handleIntermediateGet( this, tree, key, op );
 
-                return child.traverse( sub, op, keys, data );
+                if ( optSub.isPresent() ) {
+                    return child.traverse( optSub.get(), op, keys, data );
+                }
             }
         }
-        else {
-            // TODO make the throwing of this Exception be something handled / optional by the travesr
-            //  Aka combine the typeOk logic with this
-            //  If type != ok options are :
-            //    Do nothing
-            //    Throw Exception
-            //    "make" the type ok by overwriting with a new container object (got list, wanted map, so trash the list by overwriting with a new map)
-            return null;
-        }
+
+        return Optional.empty();
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/MapTraversalStep.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/MapTraversalStep.java
@@ -15,6 +15,7 @@
  */
 package com.bazaarvoice.jolt.traversr.traversal;
 
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.Traversr;
 
 import java.util.LinkedHashMap;
@@ -23,33 +24,43 @@ import java.util.Map;
 /**
  * TraversalStep that expects to handle Map objects.
  */
-public class MapTraversalStep extends BaseTraversalStep<Map<String,Object>> {
+public class MapTraversalStep<DataType> extends BaseTraversalStep<Map<String,Object>, DataType> {
 
     public MapTraversalStep( Traversr traversr, TraversalStep child ) {
         super( traversr, child );
     }
 
-    public Class getStepType() {
+    public Class<?> getStepType() {
         return Map.class;
     }
 
-    public Object newContainer() {
-        return new LinkedHashMap<String, Object>();
+    public Map<String,Object> newContainer() {
+        return new LinkedHashMap<>();
     }
 
     @Override
-    public Object get( Map<String, Object> map, String key ) {
-        return map.get( key );
+    @SuppressWarnings("unchecked")
+    public Optional<DataType> get( Map<String, Object> map, String key ) {
+
+        // This here was the whole point of adding the Optional stuff.
+        // Aka, I need a way to distinguish between the key not existing in the map
+        //  or the key existing but having a _valid_ null value.
+        if ( ! map.containsKey( key ) ) {
+            return Optional.empty();
+        }
+
+        return Optional.of( (DataType) map.get( key ) );
     }
 
     @Override
-    public Object remove( Map<String, Object> map, String key ) {
-        return map.remove( key );
+    @SuppressWarnings("unchecked")
+    public Optional<DataType> remove( Map<String, Object> map, String key ) {
+        return Optional.of( (DataType) map.remove( key ) );
     }
 
     @Override
-    public Object overwriteSet( Map<String, Object> map, String key, Object data ) {
-        map.put(  key, data );
-        return data;
+    public Optional<DataType> overwriteSet( Map<String, Object> map, String key, DataType data ) {
+        map.put( key, data );
+        return Optional.of( data );
     }
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/TraversalStep.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/traversr/traversal/TraversalStep.java
@@ -15,12 +15,14 @@
  */
 package com.bazaarvoice.jolt.traversr.traversal;
 
+import com.bazaarvoice.jolt.common.Optional;
+
 import java.util.Iterator;
 
 /**
  * A step in a JSON tree traversal.
  */
-public interface TraversalStep<T> {
+public interface TraversalStep<StepType, DataType> {
 
     /**
      * The three things you can do with a Traversal.
@@ -32,21 +34,21 @@ public interface TraversalStep<T> {
      *
      * @return data object if available, or null.
      */
-    public Object get( T tree, String key );
+    public Optional<DataType> get( StepType tree, String key );
 
     /**
      * Remove and return the data for the key from the provided tree object.
      *
      * @return data object if available, or null.
      */
-    public Object remove( T tree, String key );
+    public Optional<DataType> remove( StepType tree, String key );
 
     /**
      * Insert the data into the tree, overwriting any data that is there.
      *
      * @return returns the data object if successful or null if it could not
      */
-    public Object overwriteSet( T tree, String key, Object data );
+    public Optional<DataType> overwriteSet( StepType tree, String key, DataType data );
 
     /**
      * @return the child Traversal or null if this Traversal has no child
@@ -58,7 +60,7 @@ public interface TraversalStep<T> {
      *
      * @return new List or Map, depending on the type of the Traversal
      */
-    public Object newContainer();
+    public StepType newContainer();
 
     /**
      * Return the Class of the Generic T, so that it can be used in an
@@ -69,6 +71,9 @@ public interface TraversalStep<T> {
     public Class<?> getStepType();
 
     /**
+     * TODO : Move this to use the Java 8 Optional, so that we can distinguish
+     *  the traverse "not working" or we found an actual / valid null.
+     *
      * The meat of the Traversal.
      *
      * Pull a key from the iterator, use it to make the traversal, and then
@@ -80,5 +85,5 @@ public interface TraversalStep<T> {
      * @param data the data to place if the operation is SET
      * @return if SET, null for fail or the "data" object for ok.  if GET, PANTS
      */
-    public Object traverse( Object tree, Operation op, Iterator<String> keys, Object data );
+    public Optional<DataType> traverse( StepType tree, Operation op, Iterator<String> keys, DataType data );
 }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/ShiftrTest.java
@@ -76,6 +76,7 @@ public class ShiftrTest {
             {"transposeLHS1"},
             {"transposeLHS2"},
             {"transposeLHS3"},
+            {"transposeNestedLookup"},
             {"transposeSimple1"},
             {"transposeSimple2"},
             {"transposeSimple3"},

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/ShiftrTraversrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/shiftr/ShiftrTraversrTest.java
@@ -17,6 +17,7 @@ package com.bazaarvoice.jolt.shiftr;
 
 import com.bazaarvoice.jolt.JoltTestUtil;
 import com.bazaarvoice.jolt.JsonUtils;
+import com.bazaarvoice.jolt.common.Optional;
 import com.bazaarvoice.jolt.traversr.Traversr;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -115,8 +116,8 @@ public class ShiftrTraversrTest {
     public void getTest(String testCaseName, List<String> notUsedInThisTest, Object expected, String traversrPath, List<String> keys, Map<String, Object> tree) throws Exception
     {
         Traversr traversr = new ShiftrTraversr( traversrPath  );
-        Object actual = traversr.get( tree, keys);
+        Optional<Object> actual = traversr.get( tree, keys);
 
-        JoltTestUtil.runDiffy( testCaseName, expected, actual );
+        JoltTestUtil.runDiffy( testCaseName, expected, actual.get() );
     }
 }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/traversr/SimpleTraversalTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/traversr/SimpleTraversalTest.java
@@ -17,6 +17,7 @@ package com.bazaarvoice.jolt.traversr;
 
 import com.bazaarvoice.jolt.JoltTestUtil;
 import com.bazaarvoice.jolt.JsonUtils;
+import com.bazaarvoice.jolt.common.Optional;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -69,9 +70,9 @@ public class SimpleTraversalTest {
         Object original = JsonUtils.cloneJson( input );
         Object tree = JsonUtils.cloneJson( input );
 
-        Object actual = simpleTraversal.get( tree );
+        Optional actual = simpleTraversal.get( tree );
 
-        Assert.assertEquals( expected, actual );
+        Assert.assertEquals( expected, actual.get() );
         JoltTestUtil.runDiffy( "Get should not have modified the input", original, tree );
     }
 
@@ -80,7 +81,7 @@ public class SimpleTraversalTest {
 
         Object actual = JsonUtils.cloneJson( start );
 
-        Assert.assertEquals( toSet, simpleTraversal.set( actual, toSet ) ); // set should be successful
+        Assert.assertEquals( toSet, simpleTraversal.set( actual, toSet ).get() ); // set should be successful
 
         Assert.assertEquals( expected, actual );
     }
@@ -94,12 +95,12 @@ public class SimpleTraversalTest {
 
         Object actual = new HashMap();
 
-        Assert.assertNull( traversal.get( actual ) );
+        Assert.assertFalse( traversal.get( actual ).isPresent() );
         Assert.assertEquals( 0, ((HashMap) actual).size() ); // get didn't add anything
 
         // Add two things and validate the Auto Expand array
-        Assert.assertEquals( "one", traversal.set( actual, "one" ) );
-        Assert.assertEquals( "two", traversal.set( actual, "two" ) );
+        Assert.assertEquals( "one", traversal.set( actual, "one" ).get() );
+        Assert.assertEquals( "two", traversal.set( actual, "two" ).get() );
 
         JoltTestUtil.runDiffy( expected, actual );
     }
@@ -113,13 +114,13 @@ public class SimpleTraversalTest {
         Object expectedOne = JsonUtils.jsonToMap( "{ \"a\" : { \"b\" : \"one\" } }" );
         Object expectedTwo = JsonUtils.jsonToMap( "{ \"a\" : { \"b\" : \"two\" } }" );
 
-        Assert.assertEquals( "tuna", traversal.get( actual ) );
+        Assert.assertEquals( "tuna", traversal.get( actual ).get() );
 
         // Set twice and verify that the sets did in fact overwrite
-        Assert.assertEquals( "one", traversal.set( actual, "one" ) );
+        Assert.assertEquals( "one", traversal.set( actual, "one" ).get() );
         JoltTestUtil.runDiffy( expectedOne, actual );
 
-        Assert.assertEquals( "two", traversal.set( actual, "two" ) );
+        Assert.assertEquals( "two", traversal.set( actual, "two" ).get() );
         JoltTestUtil.runDiffy( expectedTwo, actual );
     }
 
@@ -163,8 +164,8 @@ public class SimpleTraversalTest {
                              throws Exception
     {
 
-        Object actualRemove = simpleTraversal.remove( start );
-        JoltTestUtil.runDiffy( testDescription, expectedReturn, actualRemove );
+        Optional<Object> actualRemoveOpt = simpleTraversal.remove( start );
+        JoltTestUtil.runDiffy( testDescription, expectedReturn, actualRemoveOpt.get() );
 
         JoltTestUtil.runDiffy( testDescription, expectedLeft, start );
     }
@@ -177,7 +178,7 @@ public class SimpleTraversalTest {
         SimpleTraversal<List> trav = SimpleTraversal.newTraversal( "__queryContext" );
         // barfs here, needs the 'List list =' part to trigger it
         @SuppressWarnings( "unused" )
-        List list = trav.get( tree );
+        List list = trav.get( tree ).get();
     }
 
     @Test(expectedExceptions = ClassCastException.class)
@@ -188,7 +189,7 @@ public class SimpleTraversalTest {
         SimpleTraversal<Map> trav = SimpleTraversal.newTraversal( "__queryContext.catalogLin" );
         // barfs here, needs the 'Map map =' part to trigger it
         @SuppressWarnings( "unused" )
-        Map map = trav.get( tree );
+        Map map = trav.get( tree ).get();
     }
 
     @Test(expectedExceptions = ClassCastException.class)
@@ -198,7 +199,7 @@ public class SimpleTraversalTest {
 
         SimpleTraversal<Map<String,Map>> trav = SimpleTraversal.newTraversal( "__queryContext" );
         // this works
-        Map<String,Map> queryContext = trav.get( tree );
+        Map<String,Map> queryContext = trav.get( tree ).get();
 
         // this does not
         @SuppressWarnings( "unused" )
@@ -213,7 +214,7 @@ public class SimpleTraversalTest {
 
         SimpleTraversal<Map<String,List>> trav = SimpleTraversal.newTraversal( "__queryContext" );
         // this works
-        Map<String,List> queryContext = trav.get( tree );
+        Map<String,List> queryContext = trav.get( tree ).get();
 
         // this does not
         @SuppressWarnings( "unused" )

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/utils/JoltUtilsTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/utils/JoltUtilsTest.java
@@ -275,7 +275,7 @@ public class JoltUtilsTest {
     @Test(dataProvider = "pathProvider")
     public void testToSimpleTraversrPath(Object... paths) {
         String humanReadablePath = JoltUtils.toSimpleTraversrPath(paths);
-        Assert.assertEquals(new SimpleTraversal<>(humanReadablePath).get(jsonSource), navigate(jsonSource, paths));
+        Assert.assertEquals(new SimpleTraversal<>(humanReadablePath).get(jsonSource).get(), navigate(jsonSource, paths));
     }
 
     @Test

--- a/jolt-core/src/test/resources/json/shiftr/passNullThru.json
+++ b/jolt-core/src/test/resources/json/shiftr/passNullThru.json
@@ -11,7 +11,8 @@
     "spec": {
         "key": "value",
         "bunch-O-keys" : {
-            "*" : "values.&"
+            "*" : "values.&",
+            "@(1,notLegit)" : "notLegit" // verify that if we lookup something that does not exist we do not write out a null
         }
     },
 

--- a/jolt-core/src/test/resources/json/shiftr/transposeNestedLookup.json
+++ b/jolt-core/src/test/resources/json/shiftr/transposeNestedLookup.json
@@ -1,0 +1,47 @@
+{
+    "input": {
+
+        "clientsActive" : true,
+        "clients" : {
+            "Acme" : {
+                "clientId": "Acme",
+                "index" : 1
+            },
+            "Axe" : {
+                "clientId": "AXE",
+                "index" : 0
+            }
+        },
+
+        "data": {
+            "bookId": null,
+            "bookName": "Enchiridion"
+        }
+    },
+
+    "spec": {
+        "clientsActive" : {
+            "true" : {
+                "@(2,clients)" : {
+                    // Test the ability to continue to match after doing a Transpose
+                    "*" : {
+                        "clientId" : "clientIds[@(1,index)]"
+                    }
+                },
+                // Verify that it something does not exist, it does not output a null
+                "@(2,pants)" : "pants"
+            }
+        },
+        "data" : {
+            // Verify the ability for Transpose to lookup and use a "valid" null, aka one that was in the input data
+            "@bookId": "books.@bookName"
+        }
+    },
+
+    "expected": {
+        "clientIds" : [ "AXE", "Acme" ],
+        "books" : {
+            "Enchiridion" : null
+        }
+    }
+}


### PR DESCRIPTION
 Namely, make the TransposePathElement actually work as part of a CompositeSpec.

 - Additionally, "fixed" an issue where Shiftr could not differentiate between something not existing or a legitimate null in the input data.
 - Had to introduce the notion of an Optional to the Traversal and Traversr classes, to be able to distinguish between the two cases listed above.
 - Also tried to cleanup some of the casting with more Generics.

Inspired by https://github.com/bazaarvoice/jolt/issues/135.