### PR TITLE
Added Numbr transform for transforming numeric types (e.g.; integer to double)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The Stock transforms are:
     remove      : remove data from the tree
     sort        : sort the Map key values alphabetically ( for debugging and human readability )
     cardinality : "fix" the cardinality of input data.  Eg, the "urls" element is usually a List, but if there is only one, then it is a String
+    number      : convert a numeric value from one type to another.  Eg, convert an integer to a double
 
 Each transform has it's own DSL (Domain Specific Language) in order to facilitate it's narrow job.
 
@@ -61,6 +62,7 @@ Javadoc explaining each transform DSL :
 * [remove](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/Removr.java)
 * [cardinality](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/CardinalityTransform.java)
 * [sort](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/Sortr.java)
+* [number](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/Numbr.java)
 * full qualified Java ClassName : Class implements the Transform or ContextualTransform interfaces, and can optionally be SpecDriven (marker interface)
     * [Transform](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/Transform.java) interface
     * [SpecDriven](https://github.com/bazaarvoice/jolt/blob/master/jolt-core/src/main/java/com/bazaarvoice/jolt/SpecDriven.java)

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Numbr.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Numbr.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt;
+
+import com.bazaarvoice.jolt.numbr.ArraySpec;
+import com.bazaarvoice.jolt.numbr.MapSpec;
+import com.bazaarvoice.jolt.numbr.MatcherPredicate;
+import com.bazaarvoice.jolt.numbr.Spec;
+import com.bazaarvoice.jolt.numbr.ValueSpec;
+
+import javax.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Numbr is a JOLT transform that converts numeric data from one type to another type.  For example, assume that a JSON
+ * object document can contain attribute called "rank" which can be a double on a numeric scale of 0.0 to 10.0.  When Jackson
+ * reads a document it applies the closest numeric type based on the incoming data.  So, for example, the following two documents
+ * will contain different value types when parsed by Jackson:
+ *
+ *     {"rank", 6.5}
+ *     // Deserializes to HashMap of {"rank", new Double(6.5)}
+ *
+ *     {"rank", 9}
+ *     // Deserializes to HashMap of {"rank", new Integer(9)}
+ *
+ * Most of the time this is a non-issue.  However, some systems, particularly those that perform schema validation, will raise an
+ * exception if the schema defines "rank" as a double but an integer value is found.
+ *
+ * Numbr takes a spec which explicitly describes the numberic type for each field.  For example, a Numbr with the following spec
+ * would ensure that "rank" in the examples above always has a Double value:
+ *
+ *     {"rank": "double"}
+ *
+ * When defining the spec leaf nodes contain the desired type for the value at that location.  Valid values are "int", "long", "float",
+ * and "double".  All non-leaf nodes describe how to match sub-trees.  If at any point no match is found or if a leaf-node match is found
+ * that is not a number then the value is unchanged in the result.
+ *
+ * The matcher types supported are:
+ *
+ * - Literal match
+ *
+ * In the simplest case an exact match of the provided key is used to transform the value:
+ *
+ * Example:
+ *     Spec:
+ *         {"rank":"double", "size","integer"}
+ *
+ *     Transformation:
+ *         {"rank": 7, "size": 3.2, "ignore": 42}
+ *         becomes
+ *         {"rank": 7.0, "size": 3, "ignore: 42}
+ *
+ * - Wildcard match
+ *
+ * Similar to the literal match except that "*" can be used as a wildcard in the key.  A value of exactly "*" will replace
+ * any direct numeric children to the desired type.  Note that this is not transitive beyond immediate children.
+ *
+ * Example:
+ *     Spec:
+ *         {"rank-*": "double"}
+ *
+ *     Transformation:
+ *         {"rank-fit": 3, "rank-color": 8, "rank-parent": {"rank-unchanged": 1}}
+ *         becomes
+ *         {"rank-fit": 3.0, "rank-color": 8.0, "rank-parent": {"rank-unchanged": 1}}
+ *
+ * - Or match
+ *
+ * Similar to literal and wildcard matches except multiple values can be separated with a "|"
+ *
+ * Example:
+ *     Spec:
+ *         {"lat|long|rank-*": "double"}
+ *
+ *     Transformation:
+ *         {"lat": 30, "long": 60, "rank-size": 5, "ignore": 1}
+ *         becomes
+ *         {"lat": 30.0, "long": 60.0, "rank-size": 5.0, "ignore": 1}
+ *
+ * - Array
+ *
+ * To traverse values of an array use a key with a suffix of "[]".  Note that the subsequent transform will be applied
+ * to ALL array values and that if the matching value is not an array then no transform will take place:
+ *
+ * Example:
+ *     Spec:
+ *         {"sizes[]": "double"}
+ *
+ *     Transformation:
+ *         {"sizes":[1, 2, 3.0], "ignore": 1}
+ *         becomes
+ *         {"sizes":[1.0, 2.0, 3.0], "ignore": 1}
+ *
+ *
+ * The above transforms can be nested in the spec as needed:
+ *
+ *     Spec:
+ *         {"geoLocation": {"lat|long":"double"}}
+ *
+ *     Transformation:
+ *         {"name":"Mary", "geoLocation":{"lat":30,"long":60}, "ignore": 1}
+ *         becomes
+ *         {"name":"Mary", "geoLocation":{"lat":30.0,"long":60.0}, "ignore": 1}
+ *
+ */
+public class Numbr implements SpecDriven, Transform {
+
+    private final Spec _rootSpec;
+
+    @Inject
+    public Numbr(Object spec) {
+        _rootSpec = buildSpec(spec);
+    }
+
+    private Spec buildSpec(Object spec) {
+        if (spec instanceof Map) {
+            //noinspection unchecked
+            Map<String, Object> map = (Map<String, Object>) spec;
+
+            LinkedHashMap<MatcherPredicate, Spec> mapSpecs = new LinkedHashMap<>();
+
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                String matcherString = entry.getKey();
+                List<MatcherPredicate> matchers;
+                Spec childSpec;
+
+                if (matcherString.endsWith(ArraySpec.SPEC_SUFFIX)) {
+                    // Key indicates an array
+                    String arrayKey = matcherString.substring(0, matcherString.length() - ArraySpec.SPEC_SUFFIX.length());
+                    matchers = MatcherPredicate.extractMatcherPredicates(arrayKey);
+                    childSpec = new ArraySpec(buildSpec(entry.getValue()));
+                } else {
+                    // Only other supported option is a nested map
+                    matchers = MatcherPredicate.extractMatcherPredicates(matcherString);
+                    childSpec = buildSpec(entry.getValue());
+                }
+
+                for (MatcherPredicate matcher : matchers) {
+                    mapSpecs.put(matcher, childSpec);
+                }
+            }
+
+            return new MapSpec(mapSpecs);
+        }
+
+        if (spec instanceof String) {
+            return ValueSpec.forType((String) spec);
+        }
+
+        throw new IllegalArgumentException("Unsupported type in spec: " + spec.getClass().getName());
+    }
+
+    @Override
+    public Object transform(Object input) {
+        return _rootSpec.transform(input);
+    }
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/chainr/spec/ChainrEntry.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/chainr/spec/ChainrEntry.java
@@ -19,6 +19,7 @@ import com.bazaarvoice.jolt.CardinalityTransform;
 import com.bazaarvoice.jolt.Chainr;
 import com.bazaarvoice.jolt.Defaultr;
 import com.bazaarvoice.jolt.JoltTransform;
+import com.bazaarvoice.jolt.Numbr;
 import com.bazaarvoice.jolt.Removr;
 import com.bazaarvoice.jolt.Shiftr;
 import com.bazaarvoice.jolt.Sortr;
@@ -47,6 +48,7 @@ public class ChainrEntry {
         temp.put( "remove", Removr.class.getCanonicalName() );
         temp.put( "sort", Sortr.class.getCanonicalName() );
         temp.put( "cardinality", CardinalityTransform.class.getCanonicalName() );
+        temp.put( "number", Numbr.class.getCanonicalName() );
         STOCK_TRANSFORMS = Collections.unmodifiableMap( temp );
     }
 

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/ArraySpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/ArraySpec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.numbr;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Numbr spec implementation for an array.  If the matching value is an array it will apply the provided
+ * spec's transform to all elements of the array.
+ */
+public class ArraySpec implements Spec {
+
+    public final static String SPEC_SUFFIX = "[]";
+
+    private final Spec _childSpec;
+
+    public ArraySpec(Spec childSpec) {
+        _childSpec = childSpec;
+    }
+
+    @Override
+    public Object transform(Object o) {
+        if (o instanceof List) {
+            //noinspection unchecked
+            List<Object> list = (List<Object>) o;
+            List<Object> transformed = new ArrayList<>(list.size());
+
+            for (Object element : list) {
+                Object elementTransformed = _childSpec.transform(element);
+                transformed.add(elementTransformed);
+            }
+
+            return transformed;
+        }
+
+        return o;
+    }
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/MatcherPredicate.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/MatcherPredicate.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.numbr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Base class for the predicates used to determine if a key is a match.  Ordering is:
+ *
+ * - Exact string match (ties determined by string)
+ * - Wildcard match (ties determined by wildcard string)
+ * - All matcher
+ */
+abstract public class MatcherPredicate implements Comparable<MatcherPredicate> {
+
+    private final static AllMatcher _allMatcherInstance = new AllMatcher();
+
+    public static List<MatcherPredicate> extractMatcherPredicates(String mapSpecKey) {
+        List<MatcherPredicate> matchers;
+        if ("*".equals(mapSpecKey)) {
+            matchers = new ArrayList<>(1);
+            matchers.add(_allMatcherInstance);
+        } else {
+            String[] keyParts = mapSpecKey.split("\\|");
+            matchers = new ArrayList<>(keyParts.length);
+            for (String keyPart : keyParts) {
+                if (keyPart.contains("*")) {
+                    matchers.add(new WildcardMatcher(keyPart));
+                } else {
+                    matchers.add(new ExactMatcher(keyPart));
+                }
+            }
+        }
+
+        return matchers;
+    }
+
+    abstract public boolean matches(String key);
+
+    /**
+     * Matcher for all values.
+     */
+    private static class AllMatcher extends MatcherPredicate {
+        @Override
+        public boolean matches(String key) {
+            return true;
+        }
+
+        @Override
+        public int compareTo(MatcherPredicate o) {
+            return o instanceof AllMatcher ? 0 : 1;
+        }
+    }
+
+    /**
+     * Matcher to an exact String.
+     */
+    private static class ExactMatcher extends MatcherPredicate {
+        private final String _value;
+
+        private ExactMatcher(String value) {
+            _value = value;
+        }
+
+        @Override
+        public boolean matches(String key) {
+            return _value.equals(key);
+        }
+
+        @Override
+        public int compareTo(MatcherPredicate o) {
+            return o instanceof ExactMatcher ? _value.compareTo(((ExactMatcher) o)._value) : -1;
+        }
+    }
+
+    /**
+     * Matcher that creates a regex based on the wildcards in the key.
+     */
+    private static class WildcardMatcher extends MatcherPredicate {
+        private final Pattern _regex;
+
+        private WildcardMatcher(String pattern) {
+            StringBuilder convertedPattern = new StringBuilder();
+            int i = 0;
+            int wc;
+            while (i < pattern.length() && (wc = pattern.indexOf('*', i)) != -1) {
+                if (wc != i) {
+                    convertedPattern.append(Pattern.quote(pattern.substring(i, wc)));
+                }
+                convertedPattern.append(".*");
+                i = wc + 1;
+            }
+            if (i < pattern.length()) {
+                convertedPattern.append(pattern.substring(i));
+            }
+            _regex = Pattern.compile(convertedPattern.toString());
+        }
+
+        @Override
+        public boolean matches(String key) {
+            return _regex.matcher(key).matches();
+        }
+
+        @Override
+        public int compareTo(MatcherPredicate o) {
+            if (o instanceof ExactMatcher) {
+                return 1;
+            } else if (o instanceof AllMatcher) {
+                return -1;
+            } else {
+                return _regex.pattern().compareTo(((WildcardMatcher) o)._regex.pattern());
+            }
+        }
+    }
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/Spec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/Spec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.numbr;
+
+/**
+ * Basic spec definition for a Numbr instance.
+ */
+public interface Spec {
+
+    Object transform(Object o);
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/ValueSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/numbr/ValueSpec.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.numbr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Leaf-level spec for converting numeric values.
+ */
+abstract public class ValueSpec implements Spec {
+
+    private final static Map<String, ValueSpec> _instanceTypeMap = initializeInstanceTypeMap();
+
+    private static Map<String, ValueSpec> initializeInstanceTypeMap() {
+        Map<String, ValueSpec> instanceTypeMap = new HashMap<>();
+        instanceTypeMap.put("int", new IntValueSpec());
+        instanceTypeMap.put("long", new LongValueSpec());
+        instanceTypeMap.put("float", new FloatValueSpec());
+        instanceTypeMap.put("double", new DoubleValueSpec());
+        return instanceTypeMap;
+    }
+
+    private static class IntValueSpec extends ValueSpec {
+        @Override
+        protected Number transformNumber(Number number) {
+            return number.intValue();
+        }
+    }
+
+    private static class LongValueSpec extends ValueSpec {
+        @Override
+        protected Number transformNumber(Number number) {
+            return number.longValue();
+        }
+    }
+
+    private static class FloatValueSpec extends ValueSpec {
+        @Override
+        protected Number transformNumber(Number number) {
+            return number.floatValue();
+        }
+    }
+
+    private static class DoubleValueSpec extends ValueSpec {
+        @Override
+        protected Number transformNumber(Number number) {
+            return number.doubleValue();
+        }
+    }
+
+    public static ValueSpec forType(String type) {
+        ValueSpec valueSpec = _instanceTypeMap.get(type);
+        if (valueSpec == null) {
+            throw new IllegalArgumentException("Unsupported numeric type: " + type);
+        }
+        return valueSpec;
+    }
+
+    abstract protected Number transformNumber(Number number);
+
+    @Override
+    public Object transform(Object o) {
+        if (o instanceof Number) {
+            return transformNumber((Number) o);
+        }
+        return o;
+    }
+}

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/NumbrTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/NumbrTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt;
+
+import com.bazaarvoice.jolt.numbr.MatcherPredicate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class NumbrTest {
+
+    @DataProvider
+    public Object[][] getTestCaseNames() {
+        return new Object[][] {
+                {"literalMatch"},
+                {"wildcardMatch"},
+                {"orMatch"},
+                {"arrayMatch"},
+                {"objectMatch"},
+                {"incorrectTypeMatch"},
+        };
+    }
+
+    @Test(dataProvider = "getTestCaseNames")
+    public void runTestCases(String testCaseName) throws IOException {
+
+        String testPath = "/json/numbr/" + testCaseName;
+        Map<String, Object> testUnit = JsonUtils.classpathToMap( testPath + ".json" );
+
+        Object input = testUnit.get( "input" );
+        Object spec = testUnit.get( "spec" );
+        Object expected = testUnit.get( "expected" );
+
+        Numbr numbr = new Numbr( spec );
+        Object actual = numbr.transform( input );
+
+        JoltTestUtil.runDiffy( "failed case " + testPath, expected, actual );
+    }
+
+    @Test
+    public void testMatcherPredicatePrecedence() {
+        MatcherPredicate star = MatcherPredicate.extractMatcherPredicates("*").get(0);
+        MatcherPredicate appleStar = MatcherPredicate.extractMatcherPredicates("apple-*").get(0);
+        MatcherPredicate zebraStar = MatcherPredicate.extractMatcherPredicates("zebra-*").get(0);
+        MatcherPredicate apple = MatcherPredicate.extractMatcherPredicates("apple").get(0);
+        MatcherPredicate zebra = MatcherPredicate.extractMatcherPredicates("zebra").get(0);
+
+        // Intentionally inserted out-of-order
+        MatcherPredicate[] actual = { star, zebraStar, apple, zebra, appleStar };
+        Arrays.sort(actual);
+        MatcherPredicate[] expected = { apple, zebra, appleStar, zebraStar, star };
+
+        assertEquals(actual, expected);
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/arrayMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/arrayMatch.json
@@ -1,0 +1,43 @@
+{
+    "input": {
+        "ints": [ 1, 2.1, 3, 4.7, 5],
+        "doubles-test": [ 1, 2.1, 3, 4.7, 5],
+        "double-unmodified": [ 1, 2.1, 3, 4.7, 5],
+        "nested": [
+            {
+                "size": 6,
+                "unmodifiedInt": 15
+            },
+            {
+                "size": 9,
+                "unmodifiedInt": 10
+            }
+        ],
+        "unmodifiedString": "18"
+    },
+
+    "spec": {
+        "ints[]": "int",
+        "doubles-*[]": "double",
+        "nested[]": {
+            "size": "double"
+        }
+    },
+
+    "expected": {
+        "ints": [ 1, 2, 3, 4, 5],
+        "doubles-test": [ 1.0, 2.1, 3.0, 4.7, 5.0],
+        "double-unmodified": [ 1, 2.1, 3, 4.7, 5],
+        "nested": [
+            {
+                "size": 6.0,
+                "unmodifiedInt": 15
+            },
+            {
+                "size": 9.0,
+                "unmodifiedInt": 10
+            }
+        ],
+        "unmodifiedString": "18"
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/incorrectTypeMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/incorrectTypeMatch.json
@@ -1,0 +1,26 @@
+{
+    "input": {
+        "age": "twenty",
+        "height": "tall",
+        "weight": {
+            "lbs": 145.5
+        },
+        "sizes": 7.3
+    },
+
+    "spec": {
+        "age": "int",
+        "height": "double",
+        "weight": "int",
+        "sizes[]": "int"
+    },
+
+    "expected": {
+        "age": "twenty",
+        "height": "tall",
+        "weight": {
+            "lbs": 145.5
+        },
+        "sizes": 7.3
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/literalMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/literalMatch.json
@@ -1,0 +1,28 @@
+{
+    "input": {
+        "id": 123,
+        "toInt": 3.0,
+        "toDouble": 5,
+        "unmodifiedInt": 7,
+        "unmodifiedDouble": 9.0,
+        "unmodifiedObject": {
+            "key": "value"
+        }
+    },
+
+    "spec": {
+        "toInt": "int",
+        "toDouble": "double"
+    },
+
+    "expected": {
+        "id": 123,
+        "toInt": 3,
+        "toDouble": 5.0,
+        "unmodifiedInt": 7,
+        "unmodifiedDouble": 9.0,
+        "unmodifiedObject": {
+            "key": "value"
+        }
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/objectMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/objectMatch.json
@@ -1,0 +1,82 @@
+{
+    "input": {
+        "age": 22.5,
+        "location": {
+            "place": "home",
+            "lat": 38,
+            "long": 99.03
+        },
+        "upc": 8232610032,
+        "size": {
+            "text": "good size",
+            "ratings": {
+                "first": 1,
+                "second": 2.5,
+                "third": 3.1
+            }
+        },
+        "fit": {
+            "text": "good fit",
+            "ratings": {
+                "first": 4.7,
+                "second": 5,
+                "third": 6.12
+            }
+        },
+        "unmodifiedObject": {
+            "text": "good color",
+            "ratings": {
+                "first": 7.18,
+                "second": 8,
+                "third": 9.91
+            }
+        }
+    },
+
+    "spec": {
+        "age": "int",
+        "location": {
+            "lat": "double",
+            "long": "double"
+        },
+        "size|fit": {
+            "ratings": {
+                "*": "int"
+            }
+        }
+    },
+
+    "expected": {
+        "age": 22,
+        "location": {
+            "place": "home",
+            "lat": 38.0,
+            "long": 99.03
+        },
+        "upc": 8232610032,
+        "size": {
+            "text": "good size",
+            "ratings": {
+                "first": 1,
+                "second": 2,
+                "third": 3
+            }
+        },
+        "fit": {
+            "text": "good fit",
+            "ratings": {
+                "first": 4,
+                "second": 5,
+                "third": 6
+            }
+        },
+        "unmodifiedObject": {
+            "text": "good color",
+            "ratings": {
+                "first": 7.18,
+                "second": 8,
+                "third": 9.91
+            }
+        }
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/orMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/orMatch.json
@@ -1,0 +1,38 @@
+{
+    "input": {
+        "lat": 30,
+        "long": 48,
+        "rank-fit": 5,
+        "rank-color": 8.2,
+        "age": 10.3,
+        "channel": 99.0,
+        "unmodifiedInt": 6,
+        "unmodifiedDouble": 14.3,
+        "unmodifiedObject": {
+            "forecast": "sunny",
+            "high": 78.5,
+            "pop": 5
+        }
+    },
+
+    "spec": {
+        "lat|long|rank-*": "double",
+        "age|channel": "int"
+    },
+
+    "expected": {
+        "lat": 30.0,
+        "long": 48.0,
+        "rank-fit": 5.0,
+        "rank-color": 8.2,
+        "age": 10,
+        "channel": 99,
+        "unmodifiedInt": 6,
+        "unmodifiedDouble": 14.3,
+        "unmodifiedObject": {
+            "forecast": "sunny",
+            "high": 78.5,
+            "pop": 5
+        }
+    }
+}

--- a/jolt-core/src/test/resources/json/numbr/wildcardMatch.json
+++ b/jolt-core/src/test/resources/json/numbr/wildcardMatch.json
@@ -1,0 +1,30 @@
+{
+    "input": {
+        "rank-size": 10,
+        "rank-weight": 8.5,
+        "toInt": 5.7,
+        "stayInt": 33,
+        "unmodifiedString": "foo",
+        "unmodifiedObject": {
+            "stayInt": 18,
+            "stayDouble": 9.7
+        }
+    },
+
+    "spec": {
+        "*": "int",
+        "rank-*": "double"
+    },
+
+    "expected": {
+        "rank-size": 10.0,
+        "rank-weight": 8.5,
+        "toInt": 5,
+        "stayInt": 33,
+        "unmodifiedString": "foo",
+        "unmodifiedObject": {
+            "stayInt": 18,
+            "stayDouble": 9.7
+        }
+    }
+}


### PR DESCRIPTION
Here's the backstory:  We have a Spark job that reads JSON records from source files, uses Jolt to transform them, and then continues to do other interesting things with the results.  A Spark schema (StructType) is used to validate each Jolt-transformed record.  Part of this schema defines two fields, latitude and longitude, as doubles (DoubleType).

When Jackson converts the original JSON into a Map it uses the most appropriate data type based on the content.  This means that the following JSON string:

```{"lat": 38, "long": 99.08}```

Becomes a Java Map of:

```{"lat": java.lang.Integer(38), "long": java.lang.Double(99.08)}```

Unfortunately the type validation is very strict and fails on the integer value, causing these records to be discarded.

This pull request introduces a new Transform called ```Numbr``` which ensures that numbers in JSON are converted to a specific type.  For example, the above scenario can be resolved by adding a number transform with the following spec:

```
{
    "lat|long": "double"
}
```
Full details are in the comments of the ```Numbr``` class: https://github.com/billkalter/jolt/blob/67d1ecacd3c446473c5cec82d804c8d3732b1a2a/jolt-core/src/main/java/com/bazaarvoice/jolt/Numbr.java

Any and all feedback is greatly appreciated!