### PR TITLE
Do not let parens inside string literals break parsing

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/SpecStringParser.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/SpecStringParser.java
@@ -320,11 +320,15 @@ public class SpecStringParser {
             char c = argString.charAt(i);
             switch ( c ) {
                 case '(':
-                    inBetweenBrackets = true;
+                    if (!inBetweenQuotes) {
+                        inBetweenBrackets = true;
+                    }
                     sb.append( c );
                     break;
                 case ')':
-                    inBetweenBrackets = false;
+                    if (!inBetweenQuotes) {
+                        inBetweenBrackets = false;
+                    }
                     sb.append( c );
                     break;
                 case '\'':

--- a/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
+++ b/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
@@ -16,7 +16,10 @@
             "custom1": "=toUpper(bazinga)",
             "custom2": "=toUpper('yabadabadoo')"
         },
-        "concat": "=concat(@(1,lower.leading) , ' ' , @(1,lower.trailing))",
+        "concat": {
+            "basic": "=concat(@(2,lower.leading) , ' ' , @(2,lower.trailing))",
+            "parens": "=concat(@(2,lower.leading) , ' (', @(2,lower.trailing), ')')"
+        },
         "join": "=join('_' , @(1,lower.leading) ,  , @(1,lower.trailing))"
     },
 
@@ -38,7 +41,10 @@
             "custom1": "BAZINGA",
             "custom2": "YABADABADOO"
         },
-        "concat": "the quick brown fox jumped over the lazy dog",
+        "concat": {
+            "basic": "the quick brown fox jumped over the lazy dog",
+            "parens": "the quick brown fox (jumped over the lazy dog)"
+        },
         "join": "the quick brown fox_jumped over the lazy dog"
     }
 }


### PR DESCRIPTION
The `SpecStringParser.parseFunctionArgs()` method does not ignore parentheses inside string literals, which then break parsing whenever they occur (see the added testcase).

Fixed, so that the code correctly ignores parentheses inside string literals. Note the parsing code is still quite fragile/inventing-own-wheel-like (e.g. it does not handle nested parentheses, has no way to escape embedded apostrophes inside strings, etc.).