### PR TITLE
Replace Values for some keys given a map

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/utils/JoltUtils.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/utils/JoltUtils.java
@@ -62,6 +62,54 @@ public class JoltUtils {
     }
 
     /**
+     * Replaces a value recursively from anywhere in a JSON document.
+     * NOTE: mutates its input.
+     *
+     * @param json        the Jackson Object version of the JSON document
+     *                    (contents changed by this call)
+     * @param keyToReplace the key to remove from the document
+     * @param value        the new value for the keyToReplace
+     */
+    public static void replaceRecursive( Object json, String keyToReplace, Object value ) {
+        if ( ( json == null ) || ( keyToReplace == null || value == null) ) {
+            return;
+        }
+        if ( json instanceof Map ) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> jsonMap = (Map<String, Object>) json;
+
+            // If this level of the tree has the key we are looking for, replace the value
+            if ( jsonMap.containsKey( keyToReplace ) ) {
+                jsonMap.put( keyToReplace, value );
+            }
+
+            // regardless, recurse down the tree
+            for ( Object node : jsonMap.values() ) {
+                replaceRecursive( node, keyToReplace, value );
+            }
+        }
+        if ( json instanceof List ) {
+            for ( Object node : (List) json ) {
+                replaceRecursive( node, keyToReplace, value );
+            }
+        }
+    }
+
+    /**
+     * Receives a Map with the keys and values to replace in a Jackson Object
+     * every key in the params should match with the key that want to replace
+     * value on the Jackson Object.
+     *
+     * @param json
+     * @param params
+     */
+    public static void replaceValues(Object json, Map<String, Object> params){
+        for(String key : params.keySet()) {
+            replaceRecursive(json, key, params.get(key));
+        }
+    }
+
+    /**
      * Navigate inside a json object in quick and dirty way.
      *
      * @param source the source json object

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/utils/JoltUtilsTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/utils/JoltUtilsTest.java
@@ -161,6 +161,52 @@ public class JoltUtilsTest {
         }
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void replaceRecursive() throws IOException {
+
+        String testFixture = "/json/utils/joltUtils-replaceRecursive.json";
+
+        List<Map<String, Object>> tests = (List<Map<String, Object>>) JsonUtils.classpathToObject( testFixture );
+
+        for ( Map<String,Object> testUnit : tests ) {
+            Object data = testUnit.get( "input" );
+            Map<String,Object> toReplace = (Map<String, Object>)testUnit.get( "replace" );
+            Object expected = testUnit.get( "expected" );
+
+            for(String key : toReplace.keySet()) {
+                JoltUtils.replaceRecursive(data, key, toReplace.get(key));
+            }
+
+            Diffy.Result result = diffy.diff( expected, data );
+            if (!result.isEmpty()) {
+                Assert.fail( "Failed.\nhere is a diff:\nexpected: " + JsonUtils.toJsonString(result.expected) + "\n  actual: " + JsonUtils.toJsonString(result.actual));
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void replaceValues() throws IOException {
+
+        String testFixture = "/json/utils/joltUtils-replaceRecursive.json";
+
+        List<Map<String, Object>> tests = (List<Map<String, Object>>) JsonUtils.classpathToObject( testFixture );
+
+        for ( Map<String,Object> testUnit : tests ) {
+            Object data = testUnit.get( "input" );
+            Map<String,Object> toReplace = (Map<String, Object>)testUnit.get( "replace" );
+            Object expected = testUnit.get( "expected" );
+
+            JoltUtils.replaceValues(data, toReplace);
+
+            Diffy.Result result = diffy.diff( expected, data );
+            if (!result.isEmpty()) {
+                Assert.fail( "Failed.\nhere is a diff:\nexpected: " + JsonUtils.toJsonString(result.expected) + "\n  actual: " + JsonUtils.toJsonString(result.actual));
+            }
+        }
+    }
+
     @Test( description = "No exception if we don't try to remove from an ImmutableMap.")
     public void doNotUnnecessarilyDieOnImmutableMaps() throws IOException
     {

--- a/jolt-core/src/test/resources/json/utils/joltUtils-replaceRecursive.json
+++ b/jolt-core/src/test/resources/json/utils/joltUtils-replaceRecursive.json
@@ -1,0 +1,35 @@
+[
+    {
+        "input" : {
+            "L1_A" : {
+                "L2_A" : {
+                    "L3_A" : "Good",
+                    "L3_B" : "ReplaceThis"
+                },
+                "L2_B" : "l2_b"
+            },
+            "L1_B" : "l1_b",
+
+            "L3_B" : "ReplaceThis"
+        },
+
+        "replace" : {
+            "L3_A" : "Replaced1",
+            "L3_B" : "Replaced2"
+
+        },
+
+        "expected" : {
+            "L1_A" : {
+                "L2_A" : {
+                    "L3_A" : "Replaced1",
+                    "L3_B" : "Replaced2"
+                },
+                "L2_B" : "l2_b"
+            },
+            "L1_B" : "l1_b",
+
+            "L3_B" : "Replaced2"
+        }
+    }
+]


### PR DESCRIPTION
This functionallity adds to JoltUtils the capability to change the value
of one or more nodes given a map where the key match with a node key, and the
value is the new content for that node.key.

Two methods added:

JoltUtils.replaceRecursive -> Which receive a Jackson Object a Key and a value to replace
JoltUtils.replaceValues    -> Which receive a Jackson Object and a Map with several Keys and Values to replace.

Example:

Given:

{
        "L1_A": {
                "L2_A": {
                        "L3_A": "Good",
                        "L3_B": "RemoveThis"
                },
                "L2_B": "l2_b"
        },
        "L1_B": "l1_b",

        "L3_B": "RemoveThis"
}

When:

// java code

Map<String, Object> params = new HashMap<>();
params.put("L3_A", String.valueOf(j));
params.put("L3_B", String.valueOf(j));
// data is a Jackson Object
JoltUtils.replaceValues(data, params);

Then:

{
        "L1_A": {
                "L2_A": {
                        "L3_A": "Replaced1",
                        "L3_B": "Replaced2"
                },
                "L2_B": "l2_b"
        },
        "L1_B": "l1_b",

        "L3_B": "Replaced2"
}