### PR TITLE
Split

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
@@ -45,6 +45,7 @@ public abstract class Modifier implements SpecDriven, ContextualTransform {
         STOCK_FUNCTIONS.put( "toUpper", new Strings.toUpperCase() );
         STOCK_FUNCTIONS.put( "concat", new Strings.concat() );
         STOCK_FUNCTIONS.put( "join", new Strings.join() );
+        STOCK_FUNCTIONS.put( "split", new Strings.split() );
 
         STOCK_FUNCTIONS.put( "min", new Math.min() );
         STOCK_FUNCTIONS.put( "max", new Math.max() );

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Strings.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Strings.java
@@ -18,6 +18,7 @@ package com.bazaarvoice.jolt.modifier.function;
 
 import com.bazaarvoice.jolt.common.Optional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings( "deprecated" )
@@ -70,5 +71,16 @@ public class Strings {
             }
             return Optional.<Object>of( sb.toString() );
         }
+    }
+
+    public static final class split extends Function.ArgDrivenSingleFunction<String, List> {
+      @Override
+      protected Optional<List> applySingle(final String separator, final Object source) {
+        if (source == null || separator == null) {
+          return Optional.empty();
+        } else {
+          return Optional.<List>of( Arrays.asList(source.toString().split(separator)) );
+        }
+      }
     }
 }

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/modifier/function/StringsTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/modifier/function/StringsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 Bazaarvoice, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bazaarvoice.jolt.modifier.function;
+
+import com.bazaarvoice.jolt.common.Optional;
+import org.testng.annotations.DataProvider;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+@SuppressWarnings("deprecated")
+public class StringsTest extends AbstractTester {
+
+  @DataProvider(parallel = true)
+  public Iterator<Object[]> getTestCases() {
+    List<Object[]> testCases = new LinkedList<>(  );
+
+    Function SPLIT = new Strings.split();
+
+    testCases.add( new Object[] {"split-invalid-null", SPLIT, null, Optional.empty() } );
+    testCases.add( new Object[] {"split-invalid-string", SPLIT, "", Optional.empty() } );
+
+    testCases.add( new Object[] {"split-null-string", SPLIT, new Object[] {",", null}, Optional.empty() } );
+    testCases.add( new Object[] {"split-null-separator", SPLIT, new Object[] {null, "test"}, Optional.empty() } );
+
+    testCases.add( new Object[] {"split-empty-string", SPLIT, new Object[] {",", ""}, Optional.of( Arrays.asList("") ) } );
+    testCases.add( new Object[] {"split-single-token-string", SPLIT, new Object[] {",", "test"}, Optional.of( Arrays.asList("test") )} );
+
+    testCases.add( new Object[] {"split-double-token-string", SPLIT, new Object[] {",", "test,TEST"}, Optional.of( Arrays.asList("test", "TEST") )} );
+    testCases.add( new Object[] {"split-multi-token-string", SPLIT, new Object[] {",", "test,TEST,Test,TeSt"}, Optional.of( Arrays.asList("test", "TEST", "Test", "TeSt") )} );
+    testCases.add( new Object[] {"split-spaced-token-string", SPLIT, new Object[] {",", "test, TEST"}, Optional.of( Arrays.asList("test", " TEST") )} );
+    testCases.add( new Object[] {"split-long-separator-spaced-token-string", SPLIT, new Object[] {", ", "test, TEST"}, Optional.of( Arrays.asList("test", "TEST") )} );
+
+    testCases.add( new Object[] {"split-regex-token-string", SPLIT, new Object[] {"[eE]", "test,TEST"}, Optional.of( Arrays.asList("t", "st,T", "ST") )} );
+    testCases.add( new Object[] {"split-regex2-token-string", SPLIT, new Object[] {"\\s+", "test TEST  Test    TeSt"}, Optional.of( Arrays.asList("test", "TEST", "Test", "TeSt") )} );
+
+    return testCases.iterator();
+  }
+}

--- a/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
+++ b/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
@@ -22,7 +22,13 @@
         },
         "concat": "=concat(@(1,lower.leading) , ' ' , @(1,lower.trailing))",
         "join": "=join('_' , @(1,lower.leading) ,  , @(1,lower.trailing))",
-        "toJsonString": "=toJsonString(@(2,object))"
+        "toJsonString": "=toJsonString(@(2,object))",
+        "split": {
+            "single": "=split(',', @(2,string))",
+            "multiple": "=split(' ', @(2,string))",
+            "regex": "=split('[Oo]', @(2,string))",
+            "regex2": "=split('\\s+', @(2,string))"
+        }
     },
 
     "context": {
@@ -49,6 +55,28 @@
         },
         "concat": "the quick brown fox jumped over the lazy dog",
         "join": "the quick brown fox_jumped over the lazy dog",
-        "toJsonString": "{\"leCaca\":1,\"pisu\":\"pepeLepe\"}"
+        "toJsonString": "{\"leCaca\":1,\"pisu\":\"pepeLepe\"}",
+        "split": {
+            "single": [
+                "the QuIcK brOwn fox"
+            ],
+            "multiple": [
+                "the",
+                "QuIcK",
+                "brOwn",
+                "fox"
+            ],
+            "regex": [
+                "the QuIcK br",
+                "wn f",
+                "x"
+            ],
+            "regex2": [
+                "the",
+                "QuIcK",
+                "brOwn",
+                "fox"
+            ]
+        }
     }
 }

--- a/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
+++ b/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
@@ -69,7 +69,7 @@
                 "brOwn",
                 "fox"
             ]
-        }
+        },
         "concat": {
             "basic": "the quick brown fox jumped over the lazy dog",
             "parens": "the quick brown fox (jumped over the lazy dog)"

--- a/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
+++ b/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
@@ -22,7 +22,7 @@
             "multiple": "=split(' ', @(2,string))",
             "regex": "=split('[Oo]', @(2,string))",
             "regex2": "=split('\\s+', @(2,string))"
-        }
+        },
         "concat": {
             "basic": "=concat(@(2,lower.leading) , ' ' , @(2,lower.trailing))",
             "parens": "=concat(@(2,lower.leading) , ' (', @(2,lower.trailing), ')')"


### PR DESCRIPTION
Hi,

Can you consider this pull request? It implements the split function in the "modify" operator that will take as parameter a separator (fixed string or regular expression) and a string in the JSON document. The result will be an array containing each substring delimited by the separator. If the separator is not found, it will generate an array of one element which will be the original string. This works basically as the Java `String#split()` function.

I also added the associated unit and feature tests.

Best regards