### PR TITLE
Update jackson-databind to 2.9.4 for CVE-2017-17485.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,7 +33,7 @@
         <javax-inject.version>1</javax-inject.version>
 
         <!-- module dependencies -->
-        <jackson.version>2.5.0</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
         <guice.version>4.1.0</guice.version>
         <argparse4j.version>0.4.4</argparse4j.version>
 


### PR DESCRIPTION
See: https://github.com/bazaarvoice/jolt/issues/510

This update jackson-databind to 2.9.4 for CVE-2017-17485, a remote code execution vulnerability for some uses of this library.