### PR TITLE
Revert "Added toJsonString"

### DIFF
--- a/jolt-core/pom.xml
+++ b/jolt-core/pom.xml
@@ -32,6 +32,7 @@
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
@@ -62,7 +62,6 @@ public abstract class Modifier implements SpecDriven, ContextualTransform {
         STOCK_FUNCTIONS.put( "toLong", new Objects.toLong() );
         STOCK_FUNCTIONS.put( "toBoolean", new Objects.toBoolean() );
         STOCK_FUNCTIONS.put( "toString", new Objects.toString() );
-        STOCK_FUNCTIONS.put( "toJsonString", new Objects.toJsonString() );
         STOCK_FUNCTIONS.put( "size", new Objects.size() );
 
         STOCK_FUNCTIONS.put( "noop", Function.noop );

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Objects.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Objects.java
@@ -16,7 +16,6 @@
 
 package com.bazaarvoice.jolt.modifier.function;
 
-import com.bazaarvoice.jolt.JsonUtils;
 import com.bazaarvoice.jolt.common.Optional;
 
 import java.util.Arrays;
@@ -168,13 +167,6 @@ public class Objects {
         }
     }
 
-    /**
-     * Returns json String representation of argument, wrapped in Optional
-     */
-    public static Optional<String> toJsonString(Object arg) {
-        return Optional.of( JsonUtils.toJsonString( arg ) );
-    }
-
     public static final class toInteger extends Function.SingleFunction<Integer> {
         @Override
         protected Optional<Integer> applySingle( final Object arg ) {
@@ -207,13 +199,6 @@ public class Objects {
         @Override
         protected Optional<String> applySingle( final Object arg ) {
             return Objects.toString( arg );
-        }
-    }
-
-    public static final class toJsonString extends Function.SingleFunction<String> {
-        @Override
-        protected Optional<String> applySingle( final Object arg ) {
-            return Objects.toJsonString( arg );
         }
     }
 

--- a/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
+++ b/jolt-core/src/test/resources/json/modifier/functions/stringsTests.json
@@ -1,10 +1,6 @@
 {
     "input": {
-        "string": "the QuIcK brOwn fox",
-        "object": {
-          "leCaca": 1,
-          "pisu": "pepeLepe"
-        }
+        "string": "the QuIcK brOwn fox"
     },
 
     "spec": {
@@ -21,8 +17,7 @@
             "custom2": "=toUpper('yabadabadoo')"
         },
         "concat": "=concat(@(1,lower.leading) , ' ' , @(1,lower.trailing))",
-        "join": "=join('_' , @(1,lower.leading) ,  , @(1,lower.trailing))",
-        "toJsonString": "=toJsonString(@(2,object))"
+        "join": "=join('_' , @(1,lower.leading) ,  , @(1,lower.trailing))"
     },
 
     "context": {
@@ -31,10 +26,6 @@
 
     "OVERWRITR": {
         "string" : "the QuIcK brOwn fox",
-        "object" : {
-          "leCaca" : 1,
-          "pisu" : "pepeLepe"
-        },
         "lower": {
             "leading": "the quick brown fox",
             "trailing": "jumped over the lazy dog",
@@ -48,7 +39,6 @@
             "custom2": "YABADABADOO"
         },
         "concat": "the quick brown fox jumped over the lazy dog",
-        "join": "the quick brown fox_jumped over the lazy dog",
-        "toJsonString": "{\"leCaca\":1,\"pisu\":\"pepeLepe\"}"
+        "join": "the quick brown fox_jumped over the lazy dog"
     }
 }


### PR DESCRIPTION
This reverts commit 2cf471d9fab06e724f46978e99c510e6e32138a2.

While very cool, this unfortunately messes up the maven dependency
 graph of Jolt.

Aka Jolt-core should be the root, it should not reference json-utils
 other than in test scope.