### PR TITLE
Added support for Object[] in Cardinality spec

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityLeafSpec.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/cardinality/CardinalityLeafSpec.java
@@ -20,6 +20,7 @@ import com.bazaarvoice.jolt.common.tree.WalkedPath;
 import com.bazaarvoice.jolt.exception.SpecException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,9 @@ public class CardinalityLeafSpec extends CardinalitySpec {
             if ( input instanceof List ) {
                 returnValue = input;
             }
+            else if ( input instanceof Object[] ) {
+                returnValue = Arrays.asList(((Object[]) input));
+            }
             else if ( input instanceof Map || input instanceof String || input instanceof Number || input instanceof Boolean ) {
                 Object one = parentContainer.remove( inputKey );
                 List<Object> tempList =  new ArrayList<>();
@@ -112,6 +116,9 @@ public class CardinalityLeafSpec extends CardinalitySpec {
                     returnValue = ( (List) input ).get( 0 );
                 }
                 parentContainer.put( inputKey, returnValue );
+            } else if ( input instanceof Object[] ) {
+                returnValue = ((Object[]) input)[0];
+                parentContainer.put(inputKey, returnValue);
             }
         }
 

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/CardinalityTransformTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/CardinalityTransformTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CardinalityTransformTest {
@@ -59,5 +60,45 @@ public class CardinalityTransformTest {
 
         // Should throw exception
         new CardinalityTransform( spec );
+    }
+
+    @Test
+    public void testArrayCardinalityOne() throws IOException {
+        // The above tests cover cardinality on elements that are Lists, this test covers elements that are arrays
+        Map<String, Object> input = new HashMap<String, Object>() {{
+            put("input", new Integer[]{5, 4});
+        }};
+
+        Map<String, Object> spec = new HashMap<String, Object>() {{
+            put("input", "ONE");
+        }};
+
+        Map<String, Object> expected = new HashMap<String, Object>() {{
+            put("input", 5);
+        }};
+
+        CardinalityTransform cardinalityTransform = new CardinalityTransform(spec);
+        Object actual = cardinalityTransform.transform(input);
+        JoltTestUtil.runDiffy("failed array test", expected, actual);
+    }
+
+    @Test
+    public void testArrayCardinalityMany() throws IOException {
+        // The above tests cover cardinality on elements that are Lists, this test covers elements that are arrays
+        Map<String, Object> input = new HashMap<String, Object>() {{
+            put("input", new Integer[]{5, 4});
+        }};
+
+        Map<String, Object> spec = new HashMap<String, Object>() {{
+            put("input", "MANY");
+        }};
+
+        Map<String, Object> expected = new HashMap<String, Object>() {{
+            put("input", new Integer[]{5, 4});
+        }};
+
+        CardinalityTransform cardinalityTransform = new CardinalityTransform(spec);
+        Object actual = cardinalityTransform.transform(input);
+        JoltTestUtil.runDiffy("failed array test", expected, actual);
     }
 }


### PR DESCRIPTION
fixes #617 

Added else-checks for Object[], will return Arrays.toList() in the case of MANY, or Object[0] in the case of ONE.