### PR TITLE
Issue#909:SquashNulls is not working at first level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oopenjdk8
+  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oopenjdk8

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Function.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Function.java
@@ -385,4 +385,47 @@ public interface Function {
         }
     }
 
+    /**
+     * squashNull is a special kind of null processing,the input is always a list or map as a singleton
+     *
+     * @param <T> type of return value
+     */
+    abstract class SquashFunction<T> implements Function {
+
+        public final Optional<Object> apply( final Object... args ) {
+            if(args.length == 0) {
+                return Optional.empty();
+            }
+            else if(args.length == 1) {
+                if(args[0] instanceof List ) {
+                    if(((List) args[0]).isEmpty()) {
+                        return Optional.empty();
+                    }
+                    else {
+                        return (Optional)applySingle((List) args[0]);
+                    }
+                }
+                else if( args[0] instanceof Object[] ) {
+                    if(((Object[]) args[0]).length == 0) {
+                        return Optional.empty();
+                    }
+                    else {
+                        return (Optional)applySingle(Arrays.asList(((Object[]) args[0])));
+                    }
+                }
+                else if(args[0] == null) {
+                    return Optional.empty();
+                }
+                else {
+                    return (Optional) applySingle( args[0] );
+                }
+            }
+            else {
+                return (Optional)applySingle( Arrays.asList( args ) );
+            }
+        }
+
+        protected abstract Optional<T> applySingle( final Object arg );
+    }
+
 }

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Objects.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Objects.java
@@ -252,7 +252,7 @@ public class Objects {
         }
     }
 
-    public static final class squashNulls extends Function.SingleFunction<Object> {
+    public static final class squashNulls extends Function.SquashFunction<Object> {
         @Override
         protected Optional<Object> applySingle( final Object arg ) {
             Objects.squashNulls( arg );
@@ -260,7 +260,7 @@ public class Objects {
         }
     }
 
-    public static final class recursivelySquashNulls extends Function.SingleFunction<Object> {
+    public static final class recursivelySquashNulls extends Function.SquashFunction<Object> {
         @Override
         protected Optional<Object> applySingle( final Object arg ) {
             Objects.recursivelySquashNulls( arg );

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/ModifierTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/ModifierTest.java
@@ -174,7 +174,6 @@ public class ModifierTest {
         testCases.add( new Object[]{"/json/modifier/functions/sizeTests.json", TemplatrTestCase.OVERWRITR} );
         testCases.add( new Object[]{"/json/modifier/functions/labelsLookupTest.json", TemplatrTestCase.DEFAULTR} );
         testCases.add( new Object[]{"/json/modifier/functions/valueTests.json", TemplatrTestCase.OVERWRITR }  );
-        testCases.add( new Object[]{"/json/modifier/functions/squashNullsTests.json", TemplatrTestCase.OVERWRITR }  );
 
         return testCases.iterator();
     }
@@ -183,6 +182,22 @@ public class ModifierTest {
     @Test (dataProvider = "getFunctionTests")
     public void testFunctions(String testFile, TemplatrTestCase testCase) throws Exception {
         doTest( testFile, testCase);
+    }
+
+    @Test
+    public void doSquashNullsTest() throws Exception {
+        String testFile = "/json/modifier/functions/squashNullsTests.json";
+        TemplatrTestCase testCase = TemplatrTestCase.OVERWRITR;
+        Map<String, Object> testUnit = JsonUtils.classpathToMap( testFile );
+        Object input = testUnit.get( "input" );
+        Object spec = testUnit.get( "spec" );
+        Object context = testUnit.get( "context" );
+        Object expected = testUnit.get( testCase.name() );
+        if(expected != null) {
+            Modifier modifier = testCase.getTemplatr( spec );
+            Object actual = modifier.transform( input, (Map<String, Object>) context );
+            JoltTestUtil.runDiffy( testCase.name() + " failed case " + testFile, expected, actual );
+        }
     }
 
     @DataProvider


### PR DESCRIPTION
[Associate Issue#909](https://github.com/bazaarvoice/jolt/issues/909)
The squashNull is a special kind of null processing. The input is always a list or map as a singleton. 
Can't traverse the list.

Added SquashFunction special handling squashNull and recursivelySquashNulls.