### PR TITLE
Add `Date` functions in "modify" function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/Modifier.java
@@ -22,6 +22,7 @@ import com.bazaarvoice.jolt.common.tree.WalkedPath;
 import com.bazaarvoice.jolt.exception.SpecException;
 import com.bazaarvoice.jolt.modifier.OpMode;
 import com.bazaarvoice.jolt.modifier.TemplatrSpecBuilder;
+import com.bazaarvoice.jolt.modifier.function.Dates;
 import com.bazaarvoice.jolt.modifier.function.Function;
 import com.bazaarvoice.jolt.modifier.function.Lists;
 import com.bazaarvoice.jolt.modifier.function.Math;
@@ -85,6 +86,11 @@ public abstract class Modifier implements SpecDriven, ContextualTransform {
         STOCK_FUNCTIONS.put( "elementAt", new Lists.elementAt() );
         STOCK_FUNCTIONS.put( "toList", new Lists.toList() );
         STOCK_FUNCTIONS.put( "sort", new Lists.sort() );
+
+        STOCK_FUNCTIONS.put( "fromEpochMilli", new Dates.fromEpochMilli() );
+        STOCK_FUNCTIONS.put( "toEpochMilli", new Dates.toEpochMilli() );
+        STOCK_FUNCTIONS.put( "now", new Dates.now());
+
     }
 
     private final ModifierCompositeSpec rootSpec;

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Dates.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Dates.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Alessio Zamboni <zambotn@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.modifier.function;
+
+import com.bazaarvoice.jolt.common.Optional;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Alessio Zamboni <alessio.zamboni@unitn.it>
+ * @date: 25/11/2020
+ */
+@SuppressWarnings( "deprecated" )
+public class Dates {
+  public static Optional<Long> castToLong(Object obj) {
+    if(obj instanceof Number) {
+      return Optional.of(((Number) obj).longValue());
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<String> fromEpochMilli(Object arg, Object format) {
+    Optional<Long> optEpoch = castToLong(arg);
+    if ( arg == null || !(format instanceof String) || !optEpoch.isPresent()) {
+      return Optional.empty();
+    }
+
+    Long epoch = optEpoch.get();
+    String formatStr = (String) format;
+    Date d = Date.from(Instant.ofEpochMilli(epoch));
+    SimpleDateFormat dateFormat = new SimpleDateFormat(formatStr);
+    return Optional.<String>of(dateFormat.format(d));
+  }
+
+  public static Optional<Long> toEpochMilli(Object date, Object format) {
+    if ( !((date instanceof String) && (format instanceof String)) ) {
+      return Optional.empty();
+    }
+    String formatStr = (String) format;
+    String dateStr = (String) date;
+    SimpleDateFormat dateFormat = new SimpleDateFormat(formatStr);
+
+    try {
+      Date d = dateFormat.parse(dateStr);
+      return Optional.<Long>of( d.toInstant().toEpochMilli() );
+    } catch (ParseException e) {
+      e.printStackTrace();
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<Long> now() {
+    return Optional.<Long>of(Instant.now().toEpochMilli());
+  }
+
+  public static final class now implements Function {
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public Optional<Object> apply(Object... args) {
+      return (Optional) now();
+    }
+  }
+
+  @SuppressWarnings( "unchecked" )
+  public static final class fromEpochMilli extends Function.BaseFunction<Object> {
+
+    @Override
+    protected Optional<Object> applyList(List<Object> input) {
+      if ((input == null) && (input.size() != 2)) {
+        return Optional.empty();
+      } else {
+        return (Optional) fromEpochMilli(input.get(0), input.get(1));
+      }
+    }
+
+    @Override
+    protected Optional<Object> applySingle(Object arg) {
+      return (Optional) fromEpochMilli(arg, "yyyyMMdd");
+    }
+  }
+
+  @SuppressWarnings( "unchecked" )
+  public static final class toEpochMilli extends Function.BaseFunction<Object> {
+
+    @Override
+    protected Optional<Object> applyList(List<Object> input) {
+      if ((input == null) && (input.size() != 2)) {
+        return Optional.empty();
+      } else {
+        return (Optional) toEpochMilli(input.get(0), input.get(1));
+      }
+    }
+
+    @Override
+    protected Optional<Object> applySingle(Object arg) {
+      return Optional.empty();
+    }
+  }
+}

--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Dates.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/modifier/function/Dates.java
@@ -19,7 +19,6 @@ import com.bazaarvoice.jolt.common.Optional;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 
@@ -36,6 +35,17 @@ public class Dates {
     return Optional.empty();
   }
 
+  /**
+   * Given a {@link java.lang.Number} representing an EPOCH in milliseconds and the pattern in which
+   * it has to be converted returns a String following that representation.
+   *
+   * @param arg EPOCH to be converted.
+   * @param format pattern in which the EPOCH has to be converted; it uses
+   * {@link java.text.SimpleDateFormat} format.
+   * @return String representing the date according to the <b>current locale/timezone</b>, wrapped
+   * in an {@link Optional} object.
+   * @see java.text.SimpleDateFormat
+   */
   public static Optional<String> fromEpochMilli(Object arg, Object format) {
     Optional<Long> optEpoch = castToLong(arg);
     if ( arg == null || !(format instanceof String) || !optEpoch.isPresent()) {
@@ -49,6 +59,19 @@ public class Dates {
     return Optional.<String>of(dateFormat.format(d));
   }
 
+  /**
+   * Given a String representing a {@link java.util.Date} and the pattern used to represent it,
+   * returns the EPOCH in milliseconds of that date. The pattern uses same pattern in
+   * {@link java.text.SimpleDateFormat}.
+   * If not specify otherwise inside the pattern the date refers to the
+   * <b>current locale/timezone</b>.
+   *
+   * @param date String representing the date
+   * @param format String representing the pattern
+   * @return Long representing the EPOCH in the <b>current locale/timezone</b>, wrapped in
+   * {@link Optional}.
+   * @see java.text.SimpleDateFormat
+   */
   public static Optional<Long> toEpochMilli(Object date, Object format) {
     if ( !((date instanceof String) && (format instanceof String)) ) {
       return Optional.empty();
@@ -66,6 +89,11 @@ public class Dates {
     return Optional.empty();
   }
 
+  /**
+   * This function returns current time, in EPOCH, of the <b>current locale/timezone</b>.
+   * @return Long representing current EPOCH, wrapped by {@link Optional}
+   * @see Instant#now()
+   */
   public static Optional<Long> now() {
     return Optional.<Long>of(Instant.now().toEpochMilli());
   }
@@ -101,7 +129,7 @@ public class Dates {
 
     @Override
     protected Optional<Object> applyList(List<Object> input) {
-      if ((input == null) && (input.size() != 2)) {
+      if ((input == null) || (input.size() != 2)) {
         return Optional.empty();
       } else {
         return (Optional) toEpochMilli(input.get(0), input.get(1));

--- a/jolt-core/src/test/java/com/bazaarvoice/jolt/modifier/function/DatesTest.java
+++ b/jolt-core/src/test/java/com/bazaarvoice/jolt/modifier/function/DatesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Alessio Zamboni <zambotn@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bazaarvoice.jolt.modifier.function;
+
+import com.bazaarvoice.jolt.common.Optional;
+import com.bazaarvoice.jolt.modifier.function.Dates;
+import com.bazaarvoice.jolt.modifier.function.Dates.fromEpochMilli;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Alessio Zamboni <alessio.zamboni@unitn.it>
+ * @date: 25/11/2020
+ */
+@SuppressWarnings( "deprecated" )
+public class DatesTest extends AbstractTester {
+
+  @Override
+  @DataProvider(parallel = false)
+  public Iterator<Object[]> getTestCases() {
+    List<Object[]> testCases = new LinkedList<>(  );
+    Function TO_EPOCH = new Dates.toEpochMilli();
+    Function FROM_EPOCH = new Dates.fromEpochMilli();
+
+
+    testCases.add(new Object[] {"fromEpoch-default-long", FROM_EPOCH, new Object[] {1L}, Optional.of("19700101")});
+    testCases.add(new Object[] {"fromEpoch-pattern-long", FROM_EPOCH, new Object[] {1L, "yyyy"}, Optional.of("1970")});
+    testCases.add(new Object[] {"fromEpoch-default-int", FROM_EPOCH, new Object[] {1}, Optional.of("19700101")});
+    testCases.add(new Object[] {"fromEpoch-pattern-int", FROM_EPOCH, new Object[] {1, "yyyy"}, Optional.of("1970")});
+    testCases.add(new Object[] {"fromEpoch-default-string", FROM_EPOCH, new Object[] {"1"}, Optional.empty()});
+    testCases.add(new Object[] {"fromEpoch-pattern-string", FROM_EPOCH, new Object[] {"1", "yyyy"}, Optional.empty()});
+
+    //Have to specify TIMEZONE here, otherwise is current locale
+    testCases.add(new Object[] {"toEpoch-pattern", TO_EPOCH, new Object[] {"1970-01-01#UTC", "yyyy-MM-dd#z"}, Optional.of(0L)});
+
+    return testCases.iterator();
+  }
+
+  @Test
+  public void nowReturnsEpoch() {
+    Optional<Object> opt = (new Dates.now()).apply(null);
+    assert(opt.isPresent() && (opt.get() instanceof Long));
+
+  }
+}

--- a/json-utils/src/main/java/com/bazaarvoice/jolt/JsonUtil.java
+++ b/json-utils/src/main/java/com/bazaarvoice/jolt/JsonUtil.java
@@ -82,7 +82,7 @@ public interface JsonUtil {
     String toPrettyJsonString( Object obj );
 
     /**
-     * Makes a deep copy of a Map<String, Object> object by converting it to a String and then
+     * Makes a deep copy of a {@link Map<String,Object>} object by converting it to a String and then
      * back onto stock JSON objects.
      *
      * Leverages Serialization


### PR DESCRIPTION
Add functions used to convert handle values representing `Date`s. This is crucial for many types of conversion since many JSON are including date/time related fields.
## Function added

-  `toEpochMilli(string, pattern)`: converts `string` formatted as `pattern` into EPOCH
-  `fromEpochMilli(numeric_epoch, pattern)`: converts `numeric_epoch` from a numeric format to a string formatted using `pattern`.
-  `now()`: return current EPOCH (in numeric format)