### PR TITLE
fix: Add license information to the pom.xml

### DIFF
--- a/jolt-core/pom.xml
+++ b/jolt-core/pom.xml
@@ -14,6 +14,13 @@
     <name>Jolt Core</name>
     <packaging>jar</packaging>
 
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+    
     <dependencies>
 
         <dependency>

--- a/json-utils/pom.xml
+++ b/json-utils/pom.xml
@@ -14,6 +14,13 @@
     <name>Jolt Json Utils</name>
     <packaging>jar</packaging>
 
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+    
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,14 @@
         <version>0.1.8-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
-
+    
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+    
     <artifactId>jolt</artifactId>
     <packaging>pom</packaging>
     <name>Jolt</name>
@@ -16,8 +23,8 @@
         <url>https://github.com/bazaarvoice/jolt</url>
         <connection>scm:git:git@github.com:bazaarvoice/jolt.git</connection>
         <developerConnection>scm:git:git@github.com:bazaarvoice/jolt.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>parent</module>


### PR DESCRIPTION
This PR add missing license description to project pom.xml

Fixes https://github.com/bazaarvoice/jolt/issues/1137