### PR TITLE
Added Jolt Saver Chrome Extension Link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Note
 
 * it is hosted on a free Google App Engine instance, so it may take a minute to spin up.
 * it validates in input JSON and spec client side.
+* on page refresh you will lose your spec on the Jolt demo, for saving your last performed transformation input, output, and spec in local storage you can use **Jolt Saver** Chrome Extension. It is free and available on the Chrome web store. Please find the link below.
+
+**Jolt Saver**
+: https://chrome.google.com/webstore/detail/jolt-saver/giddplgjhaloidmmhnednabjjdpnpine?hl=en&authuser=3 
 
 ## <a name="Getting_Started"></a> Getting Started
 


### PR DESCRIPTION
Hello Community,

I know that occasionally, you all get frustrated when you lose your specs just because of a page refresh.

Well, here's a solution: I have built a Chrome extension to save your last performed transformation on the Jolt Demo website.

I hope you all will like it!

https://chrome.google.com/webstore/detail/jolt-saver/giddplgjhaloidmmhnednabjjdpnpine

Please provide your valuable feedback and review on the Chrome Web Store. 

I also added the link in the Readme.md file. Please merge this PR so that everyone can use it.