### PR TITLE
Fix compatibility issue for jdk 21

### DIFF
--- a/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
+++ b/jolt-core/src/main/java/com/bazaarvoice/jolt/common/tree/WalkedPath.java
@@ -54,8 +54,8 @@ public class WalkedPath extends ArrayList<PathStep> {
         return super.add( new PathStep( treeRef, matchedElement ) );
     }
 
-    public void removeLast() {
-        remove(size() - 1);
+    public PathStep removeLast() {
+        return remove(size() - 1);
     }
 
     /**


### PR DESCRIPTION
JDK 21 [introduced](https://github.com/openjdk/jdk/commit/17ce0976e442d5fabb14daed40fa9a768989f02e) new method for ArrayList - removeLast:
```java
/**
     * {@inheritDoc}
     *
     * @throws NoSuchElementException {@inheritDoc}
     * @since 21
     */
    public E removeLast() {
    ...
```
`com.bazaarvoice.jolt.common.tree.WalkedPath` has it's own implementation of removeLast that conflicts with the one from ArrayList in JDK 21.

This PR introduces a compatibility fix, so that it works for JDK 21 and older versions as well